### PR TITLE
replace eventemitter3 with emittery

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@types/node": "10.5.1",
-    "eventemitter3": "3.1.0",
+		"emittery": "^0.4.1",
     "electron": "2.0.4",
     "is-plain-object": "2.0.4",
     "electron-json-storage": "4.1.0",

--- a/packages/node_modules/action-chain/package.json
+++ b/packages/node_modules/action-chain/package.json
@@ -15,18 +15,25 @@
 		"clean": "rimraf es lib coverage",
 		"typecheck": "tsc --noEmit",
 		"test": "jest",
-    "test:watch": "jest --watch --updateSnapshot --coverage false",
+		"test:watch": "jest --watch --updateSnapshot --coverage false",
+		"prepare": "npm run build",
 		"prebuild": "npm run clean",
 		"postbuild": "rimraf {lib,es}/**/__tests__",
 		"posttest": "npm run typecheck"
 	},
-	"keywords": [ "action", "flow" ],
-	"files": [ "lib", "es" ],
+	"keywords": [
+		"action",
+		"flow"
+	],
+	"files": [
+		"lib",
+		"es"
+	],
 	"dependencies": {
 		"@types/node": "^10.5.1",
-		"eventemitter3": "^3.1.0",
-    "tslib": "^1.9.3",
-    "color": "^3.0.0"
+		"color": "^3.0.0",
+		"emittery": "^0.4.1",
+		"tslib": "^1.9.3"
 	},
 	"devDependencies": {}
 }

--- a/packages/node_modules/action-chain/src/ActionChain.ts
+++ b/packages/node_modules/action-chain/src/ActionChain.ts
@@ -1,13 +1,21 @@
-import * as EventEmitter from 'eventemitter3'
+import { Typed as Emittery } from 'emittery'
 
 const IS_DEVELOPMENT = process.env.NODE_ENV !== 'production'
+
+export type ActionChainEvents =
+  | 'provider'
+  | 'action:start'
+  | 'action:end'
+  | 'operator:start'
+  | 'operator:end'
+  | 'operator:async'
 
 export type ExecutionContext = {
   __execution: Execution
   __path: string[]
 }
 
-export interface ActionChain<Context> extends EventEmitter {
+export interface ActionChain<Context> extends Emittery<any, ActionChainEvents> {
   getOptions(): ActionChainOptions
   getContext(executionContext: ExecutionContext): Context & ExecutionContext
 }
@@ -29,7 +37,7 @@ export function actionChainFactory<Context>(
 ): ActionChain<Context> {
   options.providerExceptions = options.providerExceptions || []
 
-  return Object.assign(new EventEmitter(), {
+  return Object.assign(new Emittery<any, ActionChainEvents>(), {
     getOptions() {
       return options
     },

--- a/packages/node_modules/action-chain/src/index.test.ts
+++ b/packages/node_modules/action-chain/src/index.test.ts
@@ -143,13 +143,13 @@ describe('CONTEXT', () => {
 })
 
 describe('PROVIDER', () => {
-  test('should track execution of providers', () => {
+  test('should track execution of providers', (done) => {
     expect.assertions(2)
     const foo = action().test((_, { foo }) => {
       expect(foo.bar()).toBe('baz')
     })
 
-    actionChain.once('provider', (task) => {
+    actionChain.once('provider').then((task) => {
       expect(task).toEqual({
         operatorId: 0,
         actionId: 0,
@@ -158,16 +158,17 @@ describe('PROVIDER', () => {
         name: 'foo',
         result: 'baz',
       })
+      done()
     })
     foo()
   })
-  test('should track execution of clas instance providers', () => {
+  test('should track execution of class instance providers', (done) => {
     expect.assertions(2)
     const foo = action().test((_, { test }) => {
       expect(test.foo()).toBe('bar')
     })
 
-    actionChain.once('provider', (task) => {
+    actionChain.once('provider').then((task) => {
       expect(task).toEqual({
         operatorId: 0,
         actionId: 0,
@@ -176,23 +177,24 @@ describe('PROVIDER', () => {
         name: 'test',
         result: 'bar',
       })
+      done()
     })
     foo()
   })
 })
 
 describe('ACTION CHAIN', () => {
-  test('should track execution', () => {
+  test('should track execution', (done) => {
     expect.assertions(4)
     const foo = action().test(() => 'foo')
 
-    actionChain.once('action:start', (data) => {
+    actionChain.once('action:start').then((data) => {
       expect(data).toEqual({
         actionId: 0,
         executionId: 0,
       })
     })
-    actionChain.once('operator:start', (data) => {
+    actionChain.once('operator:start').then((data) => {
       expect(data).toEqual({
         actionId: 0,
         executionId: 0,
@@ -202,7 +204,7 @@ describe('ACTION CHAIN', () => {
         path: [],
       })
     })
-    actionChain.once('operator:end', (data) => {
+    actionChain.once('operator:end').then((data) => {
       expect(data).toEqual({
         actionId: 0,
         executionId: 0,
@@ -214,23 +216,24 @@ describe('ACTION CHAIN', () => {
         result: 'foo',
       })
     })
-    actionChain.once('action:end', (data) => {
+    actionChain.once('action:end').then((data) => {
       expect(data).toEqual({
         actionId: 0,
         executionId: 0,
       })
+      done()
     })
 
     foo()
   })
-  test('should track async execution', () => {
+  test('should track async execution', (done) => {
     expect.assertions(2)
     const foo = () => {
       return Promise.resolve('foo')
     }
     const test = action().test(foo)
 
-    actionChain.once('operator:start', (task) => {
+    actionChain.once('operator:start').then((task) => {
       expect(task).toEqual({
         actionId: 0,
         operatorId: 0,
@@ -240,7 +243,7 @@ describe('ACTION CHAIN', () => {
         type: 'test',
       })
     })
-    actionChain.once('operator:end', (task) => {
+    actionChain.once('operator:end').then((task) => {
       expect(task).toEqual({
         actionId: 0,
         operatorId: 0,
@@ -251,48 +254,55 @@ describe('ACTION CHAIN', () => {
         isAsync: true,
         result: 'foo',
       })
+      done()
     })
 
     return test()
   })
-  test('should track path execution', () => {
+  test('should track path execution', (done) => {
     expect.assertions(4)
     const forkAction = action().test(() => Promise.resolve('foo'))
     const test = action().testFork(forkAction)
 
-    actionChain.once('operator:start', (task) => {
-      expect(task).toEqual({
-        actionId: 1,
-        operatorId: 0,
-        executionId: 0,
-        name: '',
-        path: [],
-        type: 'testFork',
-      })
-      actionChain.once('operator:start', (task) => {
-        expect(task).toEqual({
+    const expectedFlow = [
+      {
+        event: 'operator:start',
+        data: {
+          actionId: 1,
+          operatorId: 0,
+          executionId: 0,
+          name: '',
+          path: [],
+          type: 'testFork',
+        },
+      },
+      {
+        event: 'operator:start',
+        data: {
           actionId: 1,
           operatorId: 1,
           executionId: 0,
           name: '',
           path: ['fork'],
           type: 'test',
-        })
-      })
-    })
-    actionChain.once('operator:end', (task) => {
-      expect(task).toEqual({
-        actionId: 1,
-        operatorId: 1,
-        executionId: 0,
-        name: '',
-        path: ['fork'],
-        type: 'test',
-        isAsync: true,
-        result: 'foo',
-      })
-      actionChain.once('operator:end', (task) => {
-        expect(task).toEqual({
+        },
+      },
+      {
+        event: 'operator:end',
+        data: {
+          actionId: 1,
+          operatorId: 1,
+          executionId: 0,
+          name: '',
+          path: ['fork'],
+          type: 'test',
+          isAsync: true,
+          result: 'foo',
+        },
+      },
+      {
+        event: 'operator:end',
+        data: {
           actionId: 1,
           operatorId: 0,
           executionId: 0,
@@ -301,17 +311,28 @@ describe('ACTION CHAIN', () => {
           type: 'testFork',
           isAsync: true,
           result: 'foo',
-        })
-      })
-    })
+        },
+      },
+    ]
 
+    let eventCount = 0
+    const unsubscribe = actionChain.onAny((event, data) => {
+      if (event === 'operator:start' || event === 'operator:end') {
+        expect({ event, data }).toEqual(expectedFlow[eventCount])
+        eventCount++
+        if (eventCount === expectedFlow.length) {
+          unsubscribe()
+          done()
+        }
+      }
+    })
     return test()
   })
-  test('should emit event when operator has async result', () => {
+  test('should emit event when operator has async result', (done) => {
     expect.assertions(1)
     const test = action().test(() => Promise.resolve('foo'))
 
-    actionChain.once('operator:async', (task) => {
+    actionChain.once('operator:async').then((task) => {
       expect(task).toEqual({
         actionId: 0,
         operatorId: 0,
@@ -321,8 +342,9 @@ describe('ACTION CHAIN', () => {
         isAsync: true,
         type: 'test',
       })
+      done()
     })
 
-    return test()
+    test()
   })
 })


### PR DESCRIPTION
Because of an issue with importing `eventemitter3` and transpiling to commonjs/es6 switching to [`emittery`](https://github.com/sindresorhus/emittery#typescript). 

Emittery is by default async in processing listeners so I had to update some tests to handle this.

After transpiling, the ES6 version looks like:
```js
import { Typed as Emittery } from 'emittery';
```

...and the commonjs version like:
```js
var emittery_1 = require("emittery");
```

so everything should work now.
