### PR TITLE
chore(overmind): add `engines.browsers` so parcel correctly works

### DIFF
--- a/packages/node_modules/overmind/package.json
+++ b/packages/node_modules/overmind/package.json
@@ -31,6 +31,11 @@
     "es",
     "react"
   ],
+  "engines": {
+    "browsers": [
+      "last 1 Chrome versions"
+    ]
+  },
   "dependencies": {
     "@types/node": "^10.5.1",
     "action-chain": "next",


### PR DESCRIPTION
This will ensure that `parcel` correctly identifies the code we ship in `lib`/`es` and transpile it if needed. 