### PR TITLE
feat(proxy-state-tree): don't allow nesting proxies in state tree

### DIFF
--- a/packages/node_modules/proxy-state-tree/src/index.test.ts
+++ b/packages/node_modules/proxy-state-tree/src/index.test.ts
@@ -66,6 +66,19 @@ describe('OBJECTS', () => {
         tree.get().foo = 'bar2'
       }).toThrow()
     })
+    test('should throw if parts of state are nested', () => {
+      const state = {
+        foo: {
+          nested: 'bar',
+        },
+      }
+      const tree = new ProxyStateTree(state)
+      expect(() => {
+        tree.startMutationTracking()
+        tree.get().foo = tree.get().foo
+        tree.clearMutationTracking()
+      }).toThrowError(/exists in the state tree on path "foo"/i)
+    })
     test('should track SET mutations', () => {
       const state = {
         foo: 'bar',
@@ -227,6 +240,23 @@ describe('ARRAYS', () => {
       expect(() => {
         tree.get().foo.push('foo')
       }).toThrow()
+    })
+    test('should throw if parts of state are nested', () => {
+      const state = {
+        foo: [undefined],
+        bar: {
+          nested: 'baz',
+        },
+      }
+      const tree = new ProxyStateTree(state)
+      tree.startMutationTracking()
+
+      // Property mutation
+      expect(() => {
+        tree.get().foo[0] = tree.get().bar
+      }).toThrowError(/exists in the state tree on path "bar"/i)
+
+      tree.clearMutationTracking()
     })
     test('should track PUSH mutations', () => {
       const state = {

--- a/packages/node_modules/proxy-state-tree/src/proxify.ts
+++ b/packages/node_modules/proxy-state-tree/src/proxify.ts
@@ -84,7 +84,13 @@ function createArrayProxy(tree, value, path) {
           `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
         )
       }
-
+      if (value[IS_PROXY] === true) {
+        throw new Error(
+          `proxy-state-tree - You are trying to insert a value that already exists in the state tree on path "${
+            value[PATH]
+          }"`
+        )
+      }
       tree.currentMutations.push({
         method: 'set',
         path: nestedPath,
@@ -129,6 +135,13 @@ function createObjectProxy(tree, value, path) {
       if (tree.status !== STATUS.TRACKING_MUTATIONS) {
         throw new Error(
           `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
+        )
+      }
+      if (value[IS_PROXY] === true) {
+        throw new Error(
+          `proxy-state-tree - You are trying to insert a value that already exists in the state tree on path "${
+            value[PATH]
+          }"`
         )
       }
       if (shouldTrackMutations(tree, nestedPath)) {


### PR DESCRIPTION
As discussed on discord. Throwing when parts of the state tree is nested in the state. 
For mutating functions on the array proxy I choose to just see if any value is proxied and reject the insertion.  The solution for the mutating function on the array is not optimal. There should maybe be another list of mutating functions that insert a value. Currently I check every argument for all mutating functions.

There is also quite a lot of duplication in these code paths. Maybe these need to be refactored (would reduce file size too) 