### PR TITLE
fix(proxy-state-tree): allow JS Functions in State Tree

### DIFF
--- a/packages/node_modules/proxy-state-tree/src/proxify.ts
+++ b/packages/node_modules/proxy-state-tree/src/proxify.ts
@@ -118,6 +118,9 @@ function createObjectProxy(tree, value, path) {
       }
 
       if (typeof targetValue === 'function') {
+        if (targetValue.name !== 'bound evaluate') {
+          return targetValue
+        }
         return tree.options.dynamicWrapper
           ? tree.options.dynamicWrapper(tree, nestedPath, targetValue)
           : targetValue(tree, nestedPath)


### PR DESCRIPTION
in old cerebral it was possible to just put small convenience functions like:
```myState: {nameFn: val => dosomethingwith(val)) ```
into state
this fix also makes them work in proxy-state-tree. 
tested in chrome version 68.0.3440.106