### PR TITLE
feat(overmind): allow do operator to return promise

### DIFF
--- a/packages/node_modules/overmind/src/Action.ts
+++ b/packages/node_modules/overmind/src/Action.ts
@@ -125,12 +125,17 @@ export default class ActionClass<
     ) as any
   }
   do: (
-    cb: (effects: Effects, value: Value) => void
+    cb: (effects: Effects, value: Value) => void | Promise<any>
   ) => [InitialValue] extends [void]
     ? INoValueAction<State, Effects, InitialValue, Value>
     : IValueAction<State, Effects, InitialValue, Value> = (cb) => {
     const operator = (effects, value) => {
-      cb(effects, value)
+      const result = cb(effects, value)
+
+      if (result instanceof Promise) {
+        return result.then(() => value)
+      }
+
       return value
     }
 

--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -164,6 +164,7 @@ describe('OPERATORS', () => {
     const doThis: Action<string> = (action) =>
       action().do(({ foo }) => {
         expect(foo.bar()).toBe('baz')
+        return Promise.resolve('bihihi')
       })
     const config = {
       state: {
@@ -190,7 +191,9 @@ describe('OPERATORS', () => {
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
-    expect(app.actions.doThis('foo')).toBe('foo')
+    return app.actions
+      .doThis('foo')
+      .then((result) => expect(result).toBe('foo'))
   })
   test('map', () => {
     expect.assertions(1)

--- a/packages/overmind-website/api/action.md
+++ b/packages/overmind-website/api/action.md
@@ -33,7 +33,7 @@ h(Example, { name: "api/action_do" })
 
 Typically used to fire off an effect without caring about its returned result, if any.
 
-Only argument is a function that receives the **effects** registered in the application as the first argument, and the current **value** of the action as the second argument. Any returned value will be ignored. The current value of the action will be passed to the next operator.
+Only argument is a function that receives the **effects** registered in the application as the first argument, and the current **value** of the action as the second argument. Any returned value will be ignored, though you can return a promise to indicate that the do operator needs to be resolved. The current value of the action will be passed to the next operator.
 
 ## filter
 ```marksy


### PR DESCRIPTION
BREAKING CHANGE:
any returned promise from a do operator will now hold action execution until resolved