### PR TITLE
fix(action-chain): add fall through in effect proxying

### DIFF
--- a/packages/node_modules/action-chain/src/utils.ts
+++ b/packages/node_modules/action-chain/src/utils.ts
@@ -35,11 +35,13 @@ function createProxyGetHandler(
         }
         return result
       }
-    } else if (isObject(target[prop])) {
+    }
+    if (isObject(target[prop])) {
       return new Proxy(target[prop], {
         get: createProxyGetHandler(path + '.' + prop.toString(), cb),
       })
     }
+    return target[prop]
   }
 }
 


### PR DESCRIPTION
If a effect had an array property, both the `if` and `else if` were false and the Proxy was returning `undefined` 