### PR TITLE
refactor(proxy-state-tree): extracted error message into functions to reduce repetition

### DIFF
--- a/packages/node_modules/proxy-state-tree/src/proxify.ts
+++ b/packages/node_modules/proxy-state-tree/src/proxify.ts
@@ -9,14 +9,6 @@ export enum STATUS {
   TRACKING_MUTATIONS = 'TRACKING_MUTATIONS',
 }
 
-function concat(path, prop) {
-  return path === undefined ? prop : path + '.' + prop
-}
-
-function shouldTrackMutations(tree, path) {
-  return tree.options.devmode || (path && tree.pathDependencies[path])
-}
-
 const arrayMutations = new Set([
   'push',
   'shift',
@@ -27,6 +19,38 @@ const arrayMutations = new Set([
   'sort',
   'copyWithin',
 ])
+
+function concat(path, prop) {
+  return path === undefined ? prop : path + '.' + prop
+}
+
+function shouldTrackMutations(tree, path) {
+  return tree.options.devmode || (path && tree.pathDependencies[path])
+}
+
+function ensureMutationTrackingIsEnabled(tree, path) {
+  if (!tree.status.has(STATUS.TRACKING_MUTATIONS)) {
+    throw new Error(
+      `proxy-state-tree - You are mutating the path "${path}", but it is not allowed`
+    )
+  }
+}
+
+function ensureValueDosntExistInStateTreeElsewhere(value) {
+  if (value && value[IS_PROXY] === true) {
+    throw new Error(
+      `proxy-state-tree - You are trying to insert a value that already exists in the state tree on path "${
+        value[PATH]
+      }"`
+    )
+  }
+}
+
+function trackPath(tree, path) {
+  if (tree.status.has(STATUS.TRACKING_PATHS)) {
+    tree.paths[tree.paths.length - 1].add(path)
+  }
+}
 
 function createArrayProxy(tree, value, path) {
   return new Proxy(value, {
@@ -45,19 +69,13 @@ function createArrayProxy(tree, value, path) {
       }
 
       const nestedPath = concat(path, prop)
-      if (tree.status.has(STATUS.TRACKING_PATHS)) {
-        tree.paths[tree.paths.length - 1].add(nestedPath)
-      }
+      trackPath(tree, nestedPath)
 
       if (
         arrayMutations.has(String(prop)) &&
         shouldTrackMutations(tree, nestedPath)
       ) {
-        if (!tree.status.has(STATUS.TRACKING_MUTATIONS)) {
-          throw new Error(
-            `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
-          )
-        }
+        ensureMutationTrackingIsEnabled(tree, nestedPath)
         return (...args) => {
           tree.currentMutations.push({
             method: prop,
@@ -78,23 +96,15 @@ function createArrayProxy(tree, value, path) {
     set(target, prop, value) {
       const nestedPath = concat(path, prop)
 
-      if (!tree.status.has(STATUS.TRACKING_MUTATIONS)) {
-        throw new Error(
-          `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
-        )
-      }
-      if (value && value[IS_PROXY] === true) {
-        throw new Error(
-          `proxy-state-tree - You are trying to insert a value that already exists in the state tree on path "${
-            value[PATH]
-          }"`
-        )
-      }
+      ensureMutationTrackingIsEnabled(tree, nestedPath)
+      ensureValueDosntExistInStateTreeElsewhere(value)
+
       tree.currentMutations.push({
         method: 'set',
         path: nestedPath,
         args: [value],
       })
+
       return Reflect.set(target, prop, value)
     },
   })
@@ -112,9 +122,7 @@ function createObjectProxy(tree, value, path) {
 
       const targetValue = target[prop]
       const nestedPath = concat(path, prop)
-      if (tree.status.has(STATUS.TRACKING_PATHS)) {
-        tree.paths[tree.paths.length - 1].add(nestedPath)
-      }
+      trackPath(tree, nestedPath)
 
       if (typeof targetValue === 'function') {
         return tree.options.dynamicWrapper
@@ -131,18 +139,9 @@ function createObjectProxy(tree, value, path) {
     set(target, prop, value) {
       const nestedPath = concat(path, prop)
 
-      if (!tree.status.has(STATUS.TRACKING_MUTATIONS)) {
-        throw new Error(
-          `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
-        )
-      }
-      if (value && value[IS_PROXY] === true) {
-        throw new Error(
-          `proxy-state-tree - You are trying to insert a value that already exists in the state tree on path "${
-            value[PATH]
-          }"`
-        )
-      }
+      ensureMutationTrackingIsEnabled(tree, nestedPath)
+      ensureValueDosntExistInStateTreeElsewhere(value)
+
       if (shouldTrackMutations(tree, nestedPath)) {
         if (!(prop in target)) {
           tree.objectChanges.add(path)
@@ -160,11 +159,8 @@ function createObjectProxy(tree, value, path) {
     deleteProperty(target, prop) {
       const nestedPath = concat(path, prop)
 
-      if (!tree.status.has(STATUS.TRACKING_MUTATIONS)) {
-        throw new Error(
-          `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
-        )
-      }
+      ensureMutationTrackingIsEnabled(tree, nestedPath)
+
       if (shouldTrackMutations(tree, nestedPath)) {
         if (prop in target) {
           tree.objectChanges.add(path)
@@ -190,10 +186,10 @@ function proxify(tree, value, path?) {
       return proxify(tree, value[VALUE], path)
     } else if (value[IS_PROXY]) {
       return value
-    } else if (Array.isArray(value)) {
-      return createArrayProxy(tree, value, path)
     } else if (isPlainObject(value)) {
       return createObjectProxy(tree, value, path)
+    } else if (Array.isArray(value)) {
+      return createArrayProxy(tree, value, path)
     }
   }
   return value


### PR DESCRIPTION
Just cleaned up the implementation a bit. 