### PR TITLE
Experiment plugins

### DIFF
--- a/packages/node_modules/overmind-angular/src/index.ts
+++ b/packages/node_modules/overmind-angular/src/index.ts
@@ -1,6 +1,6 @@
 import OvermindApp, { EventType } from 'overmind'
 
-export type TConnect<App extends OvermindApp<any, any>> = {
+export type TConnect<App extends OvermindApp<any>> = {
   app: {
     state: App['state']
     actions: App['actions']
@@ -14,7 +14,7 @@ export type TConnect<App extends OvermindApp<any, any>> = {
 
 let nextComponentId = 0
 
-export default <App extends OvermindApp<any, any>>(app: App) => () => {
+export default <App extends OvermindApp<any>>(app: App) => () => {
   const componentId = nextComponentId++
   let componentInstanceId = 0
 

--- a/packages/node_modules/overmind-react/src/index.test.tsx
+++ b/packages/node_modules/overmind-react/src/index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as renderer from 'react-test-renderer'
-import App, { TConfig, TAction } from 'overmind'
+import App, { TAction } from 'overmind'
 import createConnect, { TConnect } from './'
 
 describe('React', () => {
@@ -21,14 +21,14 @@ describe('React', () => {
       },
     }
 
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: typeof config.state.foo
       }
       actions: {
         doThis: typeof doThis
       }
-    }>
+    }
 
     const app = new App(config)
 
@@ -63,14 +63,14 @@ describe('React', () => {
       },
     }
 
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: typeof config.state.foo
       }
       actions: {
         doThis: typeof doThis
       }
-    }>
+    }
 
     const app = new App(config)
 
@@ -108,14 +108,14 @@ describe('React', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: typeof config.state.foo
       }
       actions: {
         doThis: typeof doThis
       }
-    }>
+    }
 
     const app = new App(config)
 

--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -13,7 +13,7 @@ type Omit<T, K extends keyof T> = Pick<
     { [P in K]: never } & { [x: string]: never; [x: number]: never })[keyof T]
 >
 
-export type TConnect<App extends OvermindApp<any, any>> = {
+export type TConnect<App extends OvermindApp<any>> = {
   app: {
     state: App['state']
     actions: App['actions']
@@ -27,7 +27,7 @@ export type TConnect<App extends OvermindApp<any, any>> = {
 
 let nextComponentId = 0
 
-export default <App extends OvermindApp<any, any>>(app: App) => {
+export default <App extends OvermindApp<any>>(app: App) => {
   return <Props>(
     Component: IReactComponent<Props & TConnect<App>>
   ): IReactComponent<Omit<Props & TConnect<App>, keyof TConnect<App>>> => {

--- a/packages/node_modules/overmind-vue/src/index.ts
+++ b/packages/node_modules/overmind-vue/src/index.ts
@@ -1,7 +1,7 @@
 import Vue, { ComponentOptions } from 'vue'
 import OvermindApp, { EventType } from 'overmind'
 
-export type TConnect<App extends OvermindApp<any, any>> = {
+export type TConnect<App extends OvermindApp<any>> = {
   app: {
     state: App['state']
     actions: App['actions']
@@ -20,7 +20,7 @@ type DefaultComputed = { [key: string]: any }
 
 let nextComponentId = 0
 
-export default <App extends OvermindApp<any, any>>(app: App) => <
+export default <App extends OvermindApp<any>>(app: App) => <
   V extends Vue & App,
   Data extends DefaultData<V>,
   Methods extends DefaultMethods<V>,

--- a/packages/node_modules/overmind/src/computed.test.ts
+++ b/packages/node_modules/overmind/src/computed.test.ts
@@ -1,4 +1,4 @@
-import App, { compute, TConfig, TAction } from './'
+import App, { compute, TAction } from './'
 
 describe('Computed', () => {
   test('should instantiate app with computed', () => {
@@ -76,10 +76,10 @@ describe('Computed', () => {
         changeFoo,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: State
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)

--- a/packages/node_modules/overmind/src/derived.test.ts
+++ b/packages/node_modules/overmind/src/derived.test.ts
@@ -1,4 +1,4 @@
-import App, { derive, TConfig, TAction } from './'
+import App, { derive, TAction } from './'
 
 type State = {
   foo: string
@@ -28,13 +28,13 @@ describe('Derived', () => {
         changeFoo,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: string
         upperFoo: string
       }
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)

--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -2,7 +2,7 @@ import App, { TAction, TConfig, DynamicAction, dynamicModule } from './'
 
 describe('Overmind', () => {
   test('should instantiate app with state', () => {
-    const app = new App({
+    const config = {
       state: {
         foo: 'bar',
       },
@@ -10,7 +10,8 @@ describe('Overmind', () => {
         doThis: (action) => action.run(() => {}),
       },
       effects: {},
-    })
+    }
+    const app = new App(config)
 
     expect(app.state.foo).toEqual('bar')
   })

--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import App, { TAction, TConfig, DynamicAction, dynamicModule } from './'
+import App, { TAction, plugin } from './'
 
 describe('Overmind', () => {
   test('should instantiate app with state', () => {
@@ -37,12 +37,12 @@ describe('Overmind', () => {
         bar: fooAction,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       modules: {
         foo: typeof foo
         bar: typeof bar
       }
-    }>
+    }
 
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
@@ -60,32 +60,115 @@ describe('Overmind', () => {
     expect(app.actions.foo.foo('mip')).toEqual('mip')
     expect(app.actions.bar.bar('bop')).toEqual('bop')
   })
-  test('should allow namespaced modules to be functions', () => {
-    const foo = dynamicModule((namespace) => {
-      const fooAction: DynamicAction<string> = ({ mutate }) =>
-        mutate((state) => (state[namespace].foo = 'bar2'))
+})
 
-      return {
-        state: {
-          foo: 'bar',
-        },
-        actions: {
-          foo: fooAction,
-        },
-      }
+describe('PLUGINS', () => {
+  test('instantiate plugin state', () => {
+    const myPlugin = plugin({
+      state: {
+        pluginState: true,
+      },
     })
-
     const config = {
+      state: {
+        foo: 'bar',
+      },
+      actions: {
+        doThis: (action) => action.run(() => {}),
+      },
       modules: {
-        foo,
+        myModule: {
+          state: {
+            moduleState: true,
+          },
+        },
+      },
+      plugins: {
+        myPlugin,
       },
     }
+    const app = new App(config)
+    expect(app.state).toEqual({
+      foo: 'bar',
+      myPlugin: { pluginState: true },
+      myModule: { moduleState: true },
+    })
+    expect(app.state.myPlugin.pluginState).toBe(true)
+    expect(app.state.myModule.moduleState).toBe(true)
+  })
+  test('create plugin actions', () => {
+    const mockCallback = jest.fn()
+    const myPlugin = plugin({
+      actions: {
+        doThis: (action) =>
+          action.run(() => {
+            mockCallback('plugin')
+          }),
+      },
+    })
+    const config = {
+      actions: {
+        doThis: (action) =>
+          action.run(() => {
+            mockCallback('not plugin')
+          }),
+      },
+      plugins: {
+        myPlugin,
+      },
+    }
+    const app = new App(config)
+    app.actions.doThis()
+    expect(mockCallback.mock.calls.length).toBe(1)
+    expect(mockCallback.mock.calls[0][0]).toBe('not plugin')
+    app.actions.myPlugin.doThis()
+    expect(mockCallback.mock.calls.length).toBe(2)
+    expect(mockCallback.mock.calls[1][0]).toBe('plugin')
+  })
+  test('create plugin effects', () => {
+    const mockCallback = jest.fn()
+    const myPlugin = plugin({
+      effects: {
+        doThis: () => {
+          mockCallback('plugin')
+        },
+      },
+    })
+    const callEffects: Action = (action) =>
+      action.run((effects) => {
+        effects.doThis()
+        effects.myPlugin.doThis()
+      })
+    const config = {
+      effects: {
+        doThis: () => {
+          mockCallback('not plugin')
+        },
+      },
+      actions: {
+        callEffects,
+      },
+      plugins: {
+        myPlugin,
+      },
+    }
+    type Config = {
+      actions: typeof config.actions
+      effects: {
+        doThis: () => any
+      }
+      plugins: {
+        myPlugin: typeof myPlugin
+      }
+    }
+    type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
+    app.actions.callEffects()
 
-    expect(app.state.foo.foo).toEqual('bar')
-    expect(app.actions.foo.foo('mip')).toEqual('mip')
-    expect(app.state.foo.foo).toEqual('bar2')
+    expect(mockCallback.mock.calls.length).toBe(2)
+    expect(mockCallback.mock.calls[0][0]).toBe('not plugin')
+    expect(mockCallback.mock.calls[1][0]).toBe('plugin')
   })
 })
 
@@ -103,9 +186,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
@@ -124,12 +207,12 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: string
       }
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
@@ -158,7 +241,7 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: string
       }
@@ -166,7 +249,7 @@ describe('OPERATORS', () => {
         foo: typeof config.effects.foo
       }
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
@@ -185,9 +268,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
@@ -207,9 +290,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
 
@@ -230,9 +313,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
     return Promise.resolve(app.actions.doThis()).then((value) => {
@@ -251,9 +334,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
     expect(app.actions.doThis()).toBe('foo')
@@ -271,9 +354,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
 
@@ -289,9 +372,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
     expect(app.actions.doThis('foo')).toBe('bar')
@@ -305,9 +388,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
 
@@ -328,9 +411,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
 
@@ -351,9 +434,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
     app.actions.doThis()
@@ -371,9 +454,9 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       actions: typeof config.actions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     const app = new App(config)
     app.actions.doThis()

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -68,7 +68,7 @@ type PluginConfiguration = {
 }
 
 // We use a symbol so user can't create a FlatPlugin themself
-const PLUGIN_TOKEN = Symbol('Plugin')
+export const PLUGIN_TOKEN = Symbol('Plugin')
 
 export type Plugin<Config extends PluginConfiguration> = {
   [PLUGIN_TOKEN]: true

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -126,7 +126,7 @@ type Test = 'state' extends keyof { state: {} } ? true : false
 // prettier-ignore
 export type TState<Config extends Configuration> = (
   ([Config['state']] extends [undefined] ? {} : Config['state']) &
-  ([Config['plugins']] extends [undefined] ? { noPlugins: true } : ExtractPluginState<Config['plugins']>) &
+  ([Config['plugins']] extends [undefined] ? {} : ExtractPluginState<Config['plugins']>) &
   ([Config['modules']] extends [undefined] ? {} : ExtractModulesState<Config['modules']>)
 )
 

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -10,12 +10,15 @@ import ActionClass, {
 } from './Action'
 import Reaction from './reaction'
 import {
-  DynamicModule,
   Events,
   EventType,
   Options,
   WithoutNeverDeep,
+  EmptyIfNever,
 } from './internalTypes'
+// Needed due to Parcel + Webpack support
+const isPlainObject = require('is-plain-object')
+
 export { default as derive } from './derived'
 export { default as compute } from './computed'
 
@@ -23,9 +26,6 @@ export { IValueAction, Compose, EventType }
 
 export const log = (...objects: any[]) =>
   console.log(...objects.map((obj) => JSON.parse(JSON.stringify(obj))))
-
-export const dynamicModule = ((cb) => (namespace) =>
-  cb(namespace)) as DynamicModule
 
 /*
   BASE TYPES
@@ -37,6 +37,7 @@ export type Module = {
   effects?: any
   actions?: any
   reactions?: any
+  plugins?: object
 }
 
 type Modules = {
@@ -54,28 +55,43 @@ export type Configuration = {
 }
 
 /**
- * Internal type used to flatten plugins
+ * Plugins
  */
+
+type PluginConfiguration = {
+  onInitialize?: any
+  state?: any
+  effects?: any
+  actions?: any
+  reactions?: any
+  plugins?: object
+}
 
 // We use a symbol so user can't create a FlatPlugin themself
 const PLUGIN_TOKEN = Symbol('Plugin')
 
-type PLUGIN_TOKEN = typeof PLUGIN_TOKEN
-
-type FlatPlugin<Config extends Configuration> = {
-  [PLUGIN_TOKEN]: {
-    __state: TState<Config>
-    __actions: TActions<Config>
-    __effects: TEffects<Config>
-  }
+type FlatPlugin<Config extends PluginConfiguration> = {
+  [PLUGIN_TOKEN]: true
+  __state: TState<Config>
+  __actions: TActions<Config>
+  __effects: TEffects<Config>
 }
 
 type FlatPluginAny = {
-  [PLUGIN_TOKEN]: {
-    __state: any
-    __actions: any
-    __effects: any
-  }
+  [PLUGIN_TOKEN]: true
+  __state: any
+  __actions: any
+  __effects: any
+}
+
+export function plugin<Config extends PluginConfiguration>(
+  config: Config | ((path: Array<string>) => Config)
+): FlatPlugin<Config> {
+  return ((path) => {
+    const resolvedConf = typeof config === 'function' ? config(path) : config
+    resolvedConf[PLUGIN_TOKEN] = true
+    return resolvedConf
+  }) as any
 }
 
 /*
@@ -93,89 +109,72 @@ interface IApp extends IEffects {
  * State
  */
 
-type ExtractPluginState<T> = WithoutNeverDeep<
-  T extends FlatPluginAny
-    ? (keyof T[PLUGIN_TOKEN]['__state'] extends never
-        ? never
-        : T[PLUGIN_TOKEN]['__state'])
-    : (T extends object ? { [K in keyof T]: ExtractPluginState<T[K]> } : T)
+type ExtractPluginState<T> = EmptyIfNever<
+  WithoutNeverDeep<
+    T extends FlatPluginAny
+      ? (keyof T['__state'] extends never ? {} : T['__state'])
+      : (T extends object ? { [K in keyof T]: ExtractPluginState<T[K]> } : T)
+  >
 >
 
 type ExtractModulesState<T extends Modules> = {
-  [K in keyof T]: [T[K]['state']] extends [undefined] ? never : T[K]['state']
+  [K in keyof T]: [T[K]['state']] extends [undefined] ? {} : T[K]['state']
 }
 
-type TState<Config extends Configuration> = ([Config['state']] extends [
-  undefined
-]
-  ? {}
-  : Config['state']) &
-  ([Config['plugins']] extends [undefined]
-    ? {}
-    : ExtractPluginState<Config['plugins']>) &
-  ([Config['modules']] extends [undefined]
-    ? {}
-    : ExtractModulesState<Config['modules']>)
+type Test = 'state' extends keyof { state: {} } ? true : false
+
+// prettier-ignore
+export type TState<Config extends Configuration> = (
+  ([Config['state']] extends [undefined] ? {} : Config['state']) &
+  ([Config['plugins']] extends [undefined] ? { noPlugins: true } : ExtractPluginState<Config['plugins']>) &
+  ([Config['modules']] extends [undefined] ? {} : ExtractModulesState<Config['modules']>)
+)
 
 /**
  * Actions
  */
 
-type ExtractPluginActions<T> = WithoutNeverDeep<
-  T extends FlatPluginAny
-    ? (keyof T[PLUGIN_TOKEN]['__actions'] extends never
-        ? never
-        : T[PLUGIN_TOKEN]['__actions'])
-    : (T extends object ? { [K in keyof T]: ExtractPluginActions<T[K]> } : T)
+export type ExtractPluginActions<T> = EmptyIfNever<
+  WithoutNeverDeep<
+    T extends FlatPluginAny
+      ? (keyof T['__actions'] extends never ? never : T['__actions'])
+      : (T extends object ? { [K in keyof T]: ExtractPluginActions<T[K]> } : T)
+  >
 >
 
 type ExtractModulesActions<T extends Modules> = {
-  [K in keyof T]: [T[K]['actions']] extends [undefined]
-    ? never
-    : T[K]['actions']
+  [K in keyof T]: [T[K]['actions']] extends [undefined] ? {} : T[K]['actions']
 }
 
-type TActions<Config extends Configuration> = ([Config['actions']] extends [
-  undefined
-]
-  ? {}
-  : Config['actions']) &
-  ([Config['plugins']] extends [undefined]
-    ? {}
-    : ExtractPluginActions<Config['plugins']>) &
-  ([Config['modules']] extends [undefined]
-    ? {}
-    : ExtractModulesActions<Config['modules']>)
+// prettier-ignore
+export type TActions<Config extends Configuration> = (
+  ([Config['actions']] extends [undefined] ? {} : Config['actions']) &
+  ([Config['plugins']] extends [undefined] ? {} : ExtractPluginActions<Config['plugins']>) &
+  ([Config['modules']] extends [undefined] ? {} : ExtractModulesActions<Config['modules']>)
+)
 
 /**
  * Effects
  */
 
-type ExtractPluginEffects<T> = WithoutNeverDeep<
-  T extends FlatPluginAny
-    ? (keyof T[PLUGIN_TOKEN]['__effects'] extends never
-        ? never
-        : T[PLUGIN_TOKEN]['__effects'])
-    : (T extends object ? { [K in keyof T]: ExtractPluginEffects<T[K]> } : T)
+type ExtractPluginEffects<T> = EmptyIfNever<
+  WithoutNeverDeep<
+    T extends FlatPluginAny
+      ? (keyof T['__effects'] extends never ? never : T['__effects'])
+      : (T extends object ? { [K in keyof T]: ExtractPluginEffects<T[K]> } : T)
+  >
 >
 
 type ExtractModulesEffects<T extends Modules> = {
-  [K in keyof T]: [T[K]['effects']] extends [undefined]
-    ? never
-    : T[K]['effects']
+  [K in keyof T]: [T[K]['effects']] extends [undefined] ? {} : T[K]['effects']
 }
 
-type TEffects<Config extends Configuration> = ([Config['effects']] extends [
-  undefined
-]
-  ? {}
-  : Config['effects']) &
-  ([Config['plugins']] extends [undefined]
-    ? {}
-    : ExtractPluginEffects<Config['plugins']>) &
-  ([Config['modules']] extends [undefined]
-    ? {}
-    : ExtractModulesEffects<Config['modules']>)
+// prettier-ignore
+export type TEffects<Config extends Configuration> = (
+  ([Config['effects']] extends [undefined] ? {} : Config['effects']) &
+  ([Config['plugins']] extends [undefined] ? {} : ExtractPluginEffects<Config['plugins']>) &
+  ([Config['modules']] extends [undefined] ? {} : ExtractModulesEffects<Config['modules']>)
+)
 
 /**
  * Operations
@@ -211,10 +210,10 @@ type ToCallable<Actions> = {
 export type TAction<
   InitialValue,
   ReturnValue,
-  App extends { state: any; effects: any }
+  Config extends Configuration
 > = Compose<
-  App['state'],
-  App['effects'] & { state: App['state'] },
+  TState<Config>,
+  TEffects<Config> & { state: TState<Config> },
   InitialValue,
   ReturnValue
 >
@@ -245,12 +244,17 @@ export type Reaction = (
   action: ActionClass<IApp['state'], IApp, undefined, undefined>
 ) => any
 
-export type TReaction<App extends { state: any; effects: any }> = (
+export type TReaction<Config extends Configuration> = (
   reaction: (
-    getState: (state: App['state']) => any,
-    action: INoValueAction<App['state'], App['effects'], undefined, undefined>
+    getState: (state: TState<Config>) => any,
+    action: INoValueAction<
+      TState<Config>,
+      TEffects<Config>,
+      undefined,
+      undefined
+    >
   ) => any,
-  action: ActionClass<App['state'], App['effects'], undefined, undefined>
+  action: ActionClass<TState<Config>, TEffects<Config>, undefined, undefined>
 ) => any
 
 export type Derive<T> = (state: IApp['state']) => T
@@ -259,21 +263,13 @@ export type Compute<Input, Output> = (
   value: Input
 ) => (state: IApp['state']) => Output
 
-export type TConfig<Config extends Configuration> = {
-  state: TState<Config>
-  effects: TEffects<Config>
-  actions: TActions<Config>
-  reactions: any
-  namespaces: any
-}
-
 export type TActionCreator<App> = {
   <InitialValue = void>(): TActionCaller<InitialValue, App>
 }
 
 export type TActionCaller<InitialValue, App> = [InitialValue] extends [void]
-  ? INoValueAction<TConfig<App>['state'], App, InitialValue>
-  : IValueAction<TConfig<App>['state'], App, InitialValue>
+  ? INoValueAction<TState<App>, App, InitialValue>
+  : IValueAction<TState<App>, App, InitialValue>
 
 export type ActionCallback<App> = (action: TActionCreator<App>) => any
 
@@ -283,15 +279,12 @@ export type ActionCallback<App> = (action: TActionCreator<App>) => any
 
 const hotReloadingCache = {}
 
-export default class App<
-  Config extends Configuration,
-  EvalConfig extends TConfig<Config>
-> {
+export default class App<Config extends Configuration> {
   private proxyStateTree: ProxyStateTree
   eventHub: EventEmitter<Events>
   devtools: Devtools
-  actions: ToCallable<EvalConfig['actions']>
-  state: EvalConfig['state']
+  actions: ToCallable<TActions<Config>>
+  state: TState<Config>
   constructor(configuration: Config, options: Options = {}) {
     const name = options.name || 'MyApp'
 
@@ -304,9 +297,14 @@ export default class App<
     }
 
     /*
-      Mutate module functions into module objects
+      Mutate modules into plugins
     */
-    this.mutateModuleFunctionsIntoModules(configuration)
+    this.mutateModulesIntoPlugins(configuration)
+    /*
+      Mutate plugins functions into plugin objects
+    */
+    this.mutatePluginFunctionsIntoPlugins(configuration)
+
     /*
       Set up an eventHub to trigger information from derived, computed and reactions
     */
@@ -325,7 +323,10 @@ export default class App<
       The action chain with the context configuration
     */
     const actionChain = new ActionChain(
-      Object.assign({ state: proxyStateTree.get() }, configuration.effects),
+      Object.assign(
+        { state: proxyStateTree.get() },
+        this.getEffects(configuration)
+      ),
       { providerExceptions: ['state'] }
     )
 
@@ -410,13 +411,72 @@ export default class App<
     onInitialize.displayName = 'onInitialize'
     onInitialize(undefined)
   }
-  private mutateModuleFunctionsIntoModules(config: Configuration) {
-    if (config.modules) {
-      Object.keys(config.modules).forEach((key) => {
-        if (typeof config.modules[key] === 'function') {
-          config.modules[key] = (config.modules[key] as any)(key)
+  private setIn(target: any, path: Array<string>, value: any) {
+    const parent = path.slice(0, -1).reduce((acc, key) => acc[key], target)
+    parent[path[path.length - 1]] = value
+  }
+  private setInSafe(target: any, path: Array<string>, value: any) {
+    const parent = path.slice(0, -1).reduce((acc, key) => {
+      if (acc[key] === undefined) {
+        acc[key] = {}
+      }
+      return acc
+    }, target)
+    parent[path[path.length - 1]] = value
+  }
+  private traversePlugins(config, onTraverse: (plugin, path) => void) {
+    if (config.plugins) {
+      const traverse = (val: any, path: Array<string>) => {
+        if (val[PLUGIN_TOKEN] === true) {
+          onTraverse(val, path)
+          return
         }
+        Object.keys(val).forEach((key) => {
+          traverse(val[key], [...path, key])
+        })
+      }
+
+      traverse(config.plugins, [])
+    }
+  }
+  private mutateModulesIntoPlugins(config: Configuration) {
+    if (!config.plugins) {
+      config.plugins = {}
+    }
+    if (config.modules) {
+      Object.keys(config.modules).forEach((namespace) => {
+        const mod = config.modules[namespace]
+        config.plugins[namespace] = plugin(mod)
       })
+    }
+  }
+  private mutatePluginFunctionsIntoPlugins(config: Configuration) {
+    const transformPlugin = (val: any, path: Array<string>) => {
+      if (typeof val === 'function') {
+        const resolved = val(path)
+        if (resolved[PLUGIN_TOKEN] !== true) {
+          console.warn(`Plugins must be wrapped in 'plugin()'`)
+          return
+        }
+        this.setIn(config, path, resolved)
+        if (resolved.plugins) {
+          Object.keys(resolved.plugins).forEach((key) => {
+            transformPlugin(resolved.plugins[key], [...path, key])
+          })
+        }
+        return
+      }
+      if (!isPlainObject(val)) {
+        console.warn(`Plugins must contains only 'plugins()' and plain objects`)
+        return
+      }
+      Object.keys(val).forEach((key) => {
+        transformPlugin(val[key], [...path, key])
+      })
+    }
+
+    if (config.plugins) {
+      transformPlugin(config.plugins, ['plugins'])
     }
   }
   private initializeDevtools(host, actionChain, eventHub, proxyStateTree) {
@@ -493,33 +553,34 @@ export default class App<
     proxyStateTree,
     operators
   ) {
-    const reactions = Object.keys(configuration.reactions || {}).reduce(
-      (aggr, name) => {
-        if (typeof configuration.reactions[name] === 'function') {
-          return Object.assign(aggr, {
-            [name]: configuration.reactions[name]((stateCb, action) => {
-              action.displayName = name
-              return [stateCb, action]
-            }, operators),
+    let reactions = {}
+    const addReaction = (name, reaction) => {
+      reactions[name] = reaction((stateCb, action) => {
+        action.displayName = name
+        return [stateCb, action]
+      }, operators)
+    }
+    const addReactions = (reactions, path: Array<string> = []) => {
+      Object.keys(reactions || {}).forEach((key) => {
+        const val = reactions[key]
+        if (typeof val === 'function') {
+          addReaction([...path, key].join('.'), val)
+          return
+        }
+        if (isPlainObject(val)) {
+          Object.keys(val).forEach((subKey) => {
+            addReactions(val[subKey], [...path, subKey])
           })
         }
+      })
+    }
+    // basic reactions
+    addReactions(configuration.reactions)
+    // plugins
+    this.traversePlugins(configuration, (plugin, path) => {
+      addReactions(plugin.reactions, ['plugins', ...path])
+    })
 
-        return Object.keys(configuration.reactions[name] || {}).reduce(
-          (aggr, subName) =>
-            Object.assign(aggr, {
-              [name + '.' + subName]: configuration.reactions[name](
-                (stateCb, action) => {
-                  action.displayName = name + '.' + subName
-                  return [stateCb, action]
-                },
-                operators
-              ),
-            }),
-          {}
-        )
-      },
-      {}
-    )
     Object.keys(reactions).forEach((name) => {
       const reaction = new Reaction(eventHub, proxyStateTree, name)
       reaction.create(reactions[name][0], reactions[name][1])
@@ -527,42 +588,49 @@ export default class App<
   }
   private getState(configuration) {
     let state = {}
+    // basic state
     if (configuration.state) {
       state = this.transformStateToPlainObject(configuration.state)
     }
-    if (configuration.modules) {
-      Object.keys(configuration.modules).reduce((aggr, key) => {
-        if (configuration.modules[key].state) {
-          return Object.assign(aggr, {
-            [key]: this.transformStateToPlainObject(
-              configuration.modules[key].state
-            ),
-          })
-        }
-
-        return aggr
-      }, state)
-    }
+    // plugins state
+    this.traversePlugins(configuration, (plugin, path) => {
+      if (plugin.state) {
+        this.setInSafe(
+          state,
+          path,
+          this.transformStateToPlainObject(plugin.state)
+        )
+      }
+    })
 
     return state
+  }
+  private getEffects(configuration) {
+    let effects = {}
+    // basic state
+    if (configuration.effects) {
+      effects = configuration.effects
+    }
+    // plugins state
+    this.traversePlugins(configuration, (plugin, path) => {
+      if (plugin.effects) {
+        this.setInSafe(effects, path, plugin.effects)
+      }
+    })
+
+    return effects
   }
   private getInitializers(configuration) {
     let initializers = []
     if (configuration.onInitialize) {
       initializers.push(configuration.onInitialize)
     }
-    if (configuration.modules) {
-      initializers = Object.keys(configuration.modules).reduce((aggr, key) => {
-        if (configuration.modules[key].onInitialize) {
-          configuration.modules[key].onInitialize.displayName =
-            key + '.onInitialize'
-          return aggr.concat(configuration.modules[key].onInitialize)
-        }
-
-        return aggr
-      }, initializers)
-    }
-
+    this.traversePlugins(configuration, (plugin, path) => {
+      if (plugin.onInitialize) {
+        plugin.onInitialize.displayName = path.join('.') + '.onInitialize'
+        initializers = initializers.concat(plugin.onInitialize)
+      }
+    })
     return initializers
   }
   private transformStateToPlainObject(state: {}) {
@@ -577,17 +645,11 @@ export default class App<
     if (configuration.actions) {
       actions = configuration.actions
     }
-    if (configuration.modules) {
-      Object.keys(configuration.modules).reduce((aggr, key) => {
-        if (configuration.modules[key].actions) {
-          return Object.assign(aggr, {
-            [key]: configuration.modules[key].actions,
-          })
-        }
-
-        return aggr
-      }, actions)
-    }
+    this.traversePlugins(configuration, (plugin, path) => {
+      if (plugin.actions) {
+        this.setInSafe(actions, path, plugin.actions)
+      }
+    })
 
     const evaluatedActions = Object.keys(actions).reduce((aggr, name) => {
       if (typeof actions[name] === 'function') {
@@ -634,11 +696,7 @@ export default class App<
     const reactions = []
     const instance = this
     return {
-      add(
-        name: string,
-        stateCb: (state: TConfig<Config>['state']) => any,
-        cb: Function
-      ) {
+      add(name: string, stateCb: (state: TState<Config>) => any, cb: Function) {
         const reaction = new Reaction(
           instance.eventHub,
           instance.proxyStateTree,

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -11,10 +11,10 @@ import ActionClass, {
 import Reaction from './reaction'
 import {
   DynamicModule,
-  SubType,
   Events,
   EventType,
   Options,
+  WithoutNeverDeep,
 } from './internalTypes'
 export { default as derive } from './derived'
 export { default as compute } from './computed'
@@ -31,20 +31,50 @@ export const dynamicModule = ((cb) => (namespace) =>
   BASE TYPES
 */
 
+export type Module = {
+  onInitialize?: any
+  state?: any
+  effects?: any
+  actions?: any
+  reactions?: any
+}
+
+type Modules = {
+  [namespace: string]: Module
+}
+
 export type Configuration = {
   onInitialize?: any
   state?: any
   effects?: any
   actions?: any
   reactions?: any
-  modules?: {
-    [namespace: string]: {
-      onInitialize?: any
-      state?: any
-      effects?: any
-      actions?: any
-      reactions?: any
-    }
+  modules?: Modules
+  plugins?: object
+}
+
+/**
+ * Internal type used to flatten plugins
+ */
+
+// We use a symbol so user can't create a FlatPlugin themself
+const PLUGIN_TOKEN = Symbol('Plugin')
+
+type PLUGIN_TOKEN = typeof PLUGIN_TOKEN
+
+type FlatPlugin<Config extends Configuration> = {
+  [PLUGIN_TOKEN]: {
+    __state: TState<Config>
+    __actions: TActions<Config>
+    __effects: TEffects<Config>
+  }
+}
+
+type FlatPluginAny = {
+  [PLUGIN_TOKEN]: {
+    __state: any
+    __actions: any
+    __effects: any
   }
 }
 
@@ -59,43 +89,97 @@ interface IApp extends IEffects {
   state: IState
 }
 
-export type TState<Config extends Configuration> = [Config['state']] extends [
+/**
+ * State
+ */
+
+type ExtractPluginState<T> = WithoutNeverDeep<
+  T extends FlatPluginAny
+    ? (keyof T[PLUGIN_TOKEN]['__state'] extends never
+        ? never
+        : T[PLUGIN_TOKEN]['__state'])
+    : (T extends object ? { [K in keyof T]: ExtractPluginState<T[K]> } : T)
+>
+
+type ExtractModulesState<T extends Modules> = {
+  [K in keyof T]: [T[K]['state']] extends [undefined] ? never : T[K]['state']
+}
+
+type TState<Config extends Configuration> = ([Config['state']] extends [
   undefined
 ]
-  ? {
-      [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-        Config['modules'],
-        { state: {} }
-      >[P]['state']
-    }
-  : [Config['modules']] extends [undefined]
-    ? Config['state']
-    : Config['state'] &
-        {
-          [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-            Config['modules'],
-            { state: {} }
-          >[P]['state']
-        }
+  ? {}
+  : Config['state']) &
+  ([Config['plugins']] extends [undefined]
+    ? {}
+    : ExtractPluginState<Config['plugins']>) &
+  ([Config['modules']] extends [undefined]
+    ? {}
+    : ExtractModulesState<Config['modules']>)
 
-export type TEffects<Config extends Configuration> = [
-  Config['effects']
-] extends [undefined]
-  ? {
-      [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
-        Config['modules'],
-        { effects: object }
-      >[P]['effects']
-    }
-  : [Config['modules']] extends [undefined]
-    ? Config['effects']
-    : Config['effects'] &
-        {
-          [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
-            Config['modules'],
-            { effects: object }
-          >[P]['effects']
-        }
+/**
+ * Actions
+ */
+
+type ExtractPluginActions<T> = WithoutNeverDeep<
+  T extends FlatPluginAny
+    ? (keyof T[PLUGIN_TOKEN]['__actions'] extends never
+        ? never
+        : T[PLUGIN_TOKEN]['__actions'])
+    : (T extends object ? { [K in keyof T]: ExtractPluginActions<T[K]> } : T)
+>
+
+type ExtractModulesActions<T extends Modules> = {
+  [K in keyof T]: [T[K]['actions']] extends [undefined]
+    ? never
+    : T[K]['actions']
+}
+
+type TActions<Config extends Configuration> = ([Config['actions']] extends [
+  undefined
+]
+  ? {}
+  : Config['actions']) &
+  ([Config['plugins']] extends [undefined]
+    ? {}
+    : ExtractPluginActions<Config['plugins']>) &
+  ([Config['modules']] extends [undefined]
+    ? {}
+    : ExtractModulesActions<Config['modules']>)
+
+/**
+ * Effects
+ */
+
+type ExtractPluginEffects<T> = WithoutNeverDeep<
+  T extends FlatPluginAny
+    ? (keyof T[PLUGIN_TOKEN]['__effects'] extends never
+        ? never
+        : T[PLUGIN_TOKEN]['__effects'])
+    : (T extends object ? { [K in keyof T]: ExtractPluginEffects<T[K]> } : T)
+>
+
+type ExtractModulesEffects<T extends Modules> = {
+  [K in keyof T]: [T[K]['effects']] extends [undefined]
+    ? never
+    : T[K]['effects']
+}
+
+type TEffects<Config extends Configuration> = ([Config['effects']] extends [
+  undefined
+]
+  ? {}
+  : Config['effects']) &
+  ([Config['plugins']] extends [undefined]
+    ? {}
+    : ExtractPluginEffects<Config['plugins']>) &
+  ([Config['modules']] extends [undefined]
+    ? {}
+    : ExtractModulesEffects<Config['modules']>)
+
+/**
+ * Operations
+ */
 
 export type Mutate<Value = any> = (state: IApp['state'], value: Value) => void
 
@@ -114,12 +198,15 @@ export namespace Operation {
   ) => ReturnValue
 }
 
-export type Action<InitialValue = void, ReturnValue = any> = Compose<
-  IApp['state'],
-  IApp,
-  InitialValue,
-  ReturnValue
->
+/**
+ * Action
+ */
+
+type ToCallable<Actions> = {
+  [K in keyof Actions]: [Actions[K]] extends [Compose<any, any, any>]
+    ? ReturnType<Actions[K]>
+    : (keyof Actions[K] extends never ? never : ToCallable<Actions[K]>)
+}
 
 export type TAction<
   InitialValue,
@@ -132,12 +219,23 @@ export type TAction<
   ReturnValue
 >
 
+export type Action<InitialValue = void, ReturnValue = any> = Compose<
+  IApp['state'],
+  IApp,
+  InitialValue,
+  ReturnValue
+>
+
 export type DynamicAction<InitialValue = void, ReturnValue = any> = Compose<
   any,
   any,
   InitialValue,
   ReturnValue
 >
+
+/**
+ * Reaction, Derive & Compute
+ */
 
 export type Reaction = (
   reaction: (
@@ -162,54 +260,9 @@ export type Compute<Input, Output> = (
 ) => (state: IApp['state']) => Output
 
 export type TConfig<Config extends Configuration> = {
-  state: [Config['state']] extends [undefined]
-    ? {
-        [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-          Config['modules'],
-          { state: {} }
-        >[P]['state']
-      }
-    : [Config['modules']] extends [undefined]
-      ? Config['state']
-      : Config['state'] &
-          {
-            [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-              Config['modules'],
-              { state: {} }
-            >[P]['state']
-          }
-  effects: [Config['effects']] extends [undefined]
-    ? {
-        [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
-          Config['modules'],
-          { effects: object }
-        >[P]['effects']
-      }
-    : [Config['modules']] extends [undefined]
-      ? Config['effects']
-      : Config['effects'] &
-          {
-            [P in keyof SubType<
-              Config['modules'],
-              { effects: object }
-            >]: SubType<Config['modules'], { effects: object }>[P]['effects']
-          }
-  actions: [Config['actions']] extends [undefined]
-    ? {
-        [P in keyof SubType<Config['modules'], { actions: object }>]: SubType<
-          Config['modules'],
-          { actions: object }
-        >[P]['actions']
-      }
-    : [Config['modules']] extends [undefined]
-      ? Config['actions']
-      : Config['actions'] &
-          {
-            [P in keyof SubType<
-              Config['modules'],
-              { actions: object }
-            >]: SubType<Config['modules'], { actions: object }>[P]['actions']
-          }
+  state: TState<Config>
+  effects: TEffects<Config>
+  actions: TActions<Config>
   reactions: any
   namespaces: any
 }
@@ -237,15 +290,7 @@ export default class App<
   private proxyStateTree: ProxyStateTree
   eventHub: EventEmitter<Events>
   devtools: Devtools
-  actions: {
-    [T in keyof EvalConfig['actions']]: EvalConfig['actions'][T] extends Function
-      ? ReturnType<EvalConfig['actions'][T]>
-      : {
-          [P in keyof EvalConfig['actions'][T]]: EvalConfig['actions'][T][P] extends Function
-            ? ReturnType<EvalConfig['actions'][T][P]>
-            : undefined
-        }
-  }
+  actions: ToCallable<EvalConfig['actions']>
   state: EvalConfig['state']
   constructor(configuration: Config, options: Options = {}) {
     const name = options.name || 'MyApp'

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -201,7 +201,7 @@ export namespace Operation {
  * Action
  */
 
-type ToCallable<Actions> = {
+export type ToCallable<Actions> = {
   [K in keyof Actions]: [Actions[K]] extends [Compose<any, any, any>]
     ? ReturnType<Actions[K]>
     : (keyof Actions[K] extends never ? never : ToCallable<Actions[K]>)

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -476,7 +476,7 @@ export default class App<Config extends Configuration> {
     }
 
     if (config.plugins) {
-      transformPlugin(config.plugins, ['plugins'])
+      transformPlugin(config.plugins, [])
     }
   }
   private initializeDevtools(host, actionChain, eventHub, proxyStateTree) {
@@ -578,7 +578,7 @@ export default class App<Config extends Configuration> {
     addReactions(configuration.reactions)
     // plugins
     this.traversePlugins(configuration, (plugin, path) => {
-      addReactions(plugin.reactions, ['plugins', ...path])
+      addReactions(plugin.reactions, [...path])
     })
 
     Object.keys(reactions).forEach((name) => {

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -692,7 +692,16 @@ export default class App<Config extends Configuration> {
   addMutationListener(paths, cb) {
     return this.proxyStateTree.addMutationListener(paths, cb)
   }
-  createReactionFactory(prefix: string) {
+  createReactionFactory(
+    prefix: string
+  ): {
+    add: (
+      name: string,
+      stateCb: (state: TState<Config>) => any,
+      cb: Function
+    ) => void
+    dispose: () => void
+  } {
     const reactions = []
     const instance = this
     return {

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -70,7 +70,7 @@ type PluginConfiguration = {
 // We use a symbol so user can't create a FlatPlugin themself
 const PLUGIN_TOKEN = Symbol('Plugin')
 
-type FlatPlugin<Config extends PluginConfiguration> = {
+export type Plugin<Config extends PluginConfiguration> = {
   [PLUGIN_TOKEN]: true
   __state: TState<Config>
   __actions: TActions<Config>
@@ -86,7 +86,7 @@ type FlatPluginAny = {
 
 export function plugin<Config extends PluginConfiguration>(
   config: Config | ((path: Array<string>) => Config)
-): FlatPlugin<Config> {
+): Plugin<Config> {
   return ((path) => {
     const resolvedConf = typeof config === 'function' ? config(path) : config
     resolvedConf[PLUGIN_TOKEN] = true

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -458,7 +458,7 @@ export default class App<Config extends Configuration> {
           console.warn(`Plugins must be wrapped in 'plugin()'`)
           return
         }
-        this.setIn(config, path, resolved)
+        this.setIn(config.plugins, path, resolved)
         if (resolved.plugins) {
           Object.keys(resolved.plugins).forEach((key) => {
             transformPlugin(resolved.plugins[key], [...path, key])

--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -10,11 +10,6 @@ export type DynamicModule = <
   cb: (namespace: string) => T
 ) => ReturnType<typeof cb>
 
-export type SubType<Base, Condition> = Pick<
-  Base,
-  { [Key in keyof Base]: Base[Key] extends Condition ? Key : never }[keyof Base]
->
-
 export type Options = {
   name?: string
   devtools?: string
@@ -95,3 +90,38 @@ export interface Events {
     name: string
   }
 }
+
+/**
+ * NotNever
+ */
+
+type NotNeverKeys<T> = {
+  [P in keyof T]: T[P] extends never ? never : P
+}[keyof T]
+
+/**
+ * Filter properties removing `never`
+ */
+// prettier-ignore
+export type WithoutNever<T> = (
+  // if the output has no keys... (all keys filtered out)
+  keyof Pick<T, NotNeverKeys<T>> extends never
+  // ...return never
+  ? never
+  // otherwise we return the filtered object
+  : { [K in keyof Pick<T, NotNeverKeys<T>>]: Pick<T, NotNeverKeys<T>>[K] });
+
+// because WithoutNever return never if there are no properties
+// calling WithoutNever multiple time cleanup stuff like { lvl1: { lvl2: { lvl3: never } } }
+// prettier-ignore
+export type WithoutNeverDeep<T> = (
+  WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+    WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+      WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+        WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+          T
+        >>>>>
+      >>>>>
+    >>>>>
+  >>>>>
+);

--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -1,15 +1,3 @@
-export type DynamicModule = <
-  T extends {
-    onInitialize?: any
-    state?: any
-    effects?: any
-    actions?: any
-    reactions?: any
-  }
->(
-  cb: (namespace: string) => T
-) => ReturnType<typeof cb>
-
 export type Options = {
   name?: string
   devtools?: string
@@ -95,6 +83,8 @@ export interface Events {
  * NotNever
  */
 
+export type EmptyIfNever<T> = [T] extends [never] ? {} : T
+
 type NotNeverKeys<T> = {
   [P in keyof T]: T[P] extends never ? never : P
 }[keyof T]
@@ -102,6 +92,7 @@ type NotNeverKeys<T> = {
 /**
  * Filter properties removing `never`
  */
+
 // prettier-ignore
 export type WithoutNever<T> = (
   // if the output has no keys... (all keys filtered out)
@@ -115,13 +106,13 @@ export type WithoutNever<T> = (
 // calling WithoutNever multiple time cleanup stuff like { lvl1: { lvl2: { lvl3: never } } }
 // prettier-ignore
 export type WithoutNeverDeep<T> = (
-  WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
-    WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+  // WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+    // WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
       WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
         WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
           T
         >>>>>
       >>>>>
-    >>>>>
-  >>>>>
+    // >>>>>
+  // >>>>>
 );

--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -109,9 +109,11 @@ export type WithoutNeverDeep<T> = (
   // WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
     // WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
       WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
-        WithoutNever<WithoutNever<WithoutNever<WithoutNever<WithoutNever<
-          T
-        >>>>>
+        WithoutNever<WithoutNever<WithoutNever<WithoutNever<
+          WithoutNever<
+            T
+          >
+        >>>>
       >>>>>
     // >>>>>
   // >>>>>

--- a/packages/node_modules/overmind/src/reaction.test.ts
+++ b/packages/node_modules/overmind/src/reaction.test.ts
@@ -1,4 +1,4 @@
-import App, { TConfig, TAction, TReaction } from './'
+import App, { TAction, TReaction, TActions, plugin } from './'
 
 describe('Reaction', () => {
   test('should instantiate app with reactions', () => {
@@ -22,13 +22,100 @@ describe('Reaction', () => {
         react,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: string
       }
       actions: typeof config.actions
       reactions: typeof config.reactions
-    }>
+    }
+    type Action<Input = void, Output = any> = TAction<Input, Output, Config>
+    type Reaction = TReaction<Config>
+    const app = new App(config)
+
+    app.actions.foo()
+    expect(hasRunReaction).toBe(true)
+  })
+  test('should instantiate reactions in module', () => {
+    let hasRunReaction = false
+    const foo: Action = ({ mutate }) => mutate((state) => (state.foo = 'bar2'))
+    const react: Reaction = (reaction, { run }) =>
+      reaction(
+        (state) => state.foo,
+        run(() => {
+          hasRunReaction = true
+        })
+      )
+    const config = {
+      state: {
+        foo: 'bar',
+      },
+      actions: {
+        foo,
+      },
+      modules: {
+        myModule: {
+          reactions: {
+            react,
+          },
+        },
+      },
+    }
+    type Config = {
+      state: {
+        foo: string
+      }
+      actions: typeof config.actions
+      namespaces: typeof config.modules
+    }
+    type Action<Input = void, Output = any> = TAction<Input, Output, Config>
+    type Reaction = TReaction<Config>
+    const app = new App(config)
+
+    app.actions.foo()
+    expect(hasRunReaction).toBe(true)
+  })
+  test('should instantiate reactions in plugin', () => {
+    let hasRunReaction = false
+    const foo: Action = ({ mutate }) => mutate((state) => (state.foo = 'bar2'))
+    const react: Reaction = (reaction, { run }) =>
+      reaction(
+        (state) => state.foo,
+        run(() => {
+          hasRunReaction = true
+        })
+      )
+    const myPlugin = plugin({
+      state: {
+        yolo: true,
+      },
+      reactions: {
+        react,
+      },
+    })
+    const config = {
+      state: {
+        foo: 'bar',
+      },
+      actions: {
+        foo,
+      },
+      plugins: {
+        myPlugin,
+      },
+    }
+    type State = {
+      foo: string
+    }
+    type Config = {
+      state: State
+      effects: any
+      actions: typeof config.actions
+      plugins: {
+        myPlugin: typeof myPlugin
+      }
+    }
+    type TheActions = TActions<Config>
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     type Reaction = TReaction<Config>
     const app = new App(config)
@@ -62,13 +149,13 @@ describe('Reaction', () => {
         react,
       },
     }
-    type Config = TConfig<{
+    type Config = {
       state: {
         foo: typeof config.state.foo
       }
       actions: typeof config.actions
       reactions: typeof config.reactions
-    }>
+    }
     type Action<Input = void, Output = any> = TAction<Input, Output, Config>
     type Reaction = TReaction<Config>
     const app = new App(config)


### PR DESCRIPTION
This is a first draft of a `plugins` feature designed for library author allowing them to create `plugins`.

Unlike `modules` plugins
- allow arbitrary nesting
- allow plugins in plugins
- need to be wrapped in `plugin()` factory