### PR TITLE
fix(overmind): extract modules into its own function

### DIFF
--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,10 @@
-import App, { TAction, TConfig, DynamicAction, dynamicModule } from './'
+import App, {
+  DynamicAction,
+  TAction,
+  TConfig,
+  dynamicModule,
+  modules,
+} from './'
 
 describe('Overmind', () => {
   test('should instantiate app with state', () => {
@@ -14,8 +20,8 @@ describe('Overmind', () => {
 
     expect(app.state.foo).toEqual('bar')
   })
-  test('should instantiate app with namespaces', () => {
-    const fooAction: Action<string> = ({ run }) => run(() => {})
+  test('should instantiate app with modules', () => {
+    const fooAction: TAction<string> = ({ run }) => run(() => {})
 
     const foo = {
       state: {
@@ -36,21 +42,16 @@ describe('Overmind', () => {
         bar: fooAction,
       },
     }
-    type Config = TConfig<{
-      modules: {
-        foo: typeof foo
-        bar: typeof bar
-      }
-    }>
 
-    type Action<Input = void, Output = any> = TAction<Input, Output, Config>
-
-    const config = {
+    const config = modules({
       modules: {
         foo,
         bar,
       },
-    }
+    })
+
+    type Config = TConfig<typeof config>
+    type Action<Input = void, Output = any> = TAction<Input, Output, Config>
 
     const app = new App(config)
 
@@ -74,11 +75,11 @@ describe('Overmind', () => {
       }
     })
 
-    const config = {
+    const config = modules({
       modules: {
         foo,
       },
-    }
+    })
 
     const app = new App(config)
 

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -19,6 +19,8 @@ import {
 } from './internalTypes'
 import Reaction from './reaction'
 
+export { modules } from './modules'
+
 export { IValueAction, Compose, EventType }
 
 export const log = (...objects: any[]) =>
@@ -37,15 +39,6 @@ export type Configuration = {
   effects?: any
   actions?: any
   reactions?: any
-  modules?: {
-    [namespace: string]: {
-      onInitialize?: any
-      state?: any
-      effects?: any
-      actions?: any
-      reactions?: any
-    }
-  }
 }
 
 /*
@@ -67,43 +60,9 @@ type StateNode<State extends object> = {
       : State[P] extends object ? StateNode<State[P]> : State[P]
 }
 
-export type TState<Config extends Configuration> = [Config['state']] extends [
-  undefined
-]
-  ? {
-      [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-        Config['modules'],
-        { state: {} }
-      >[P]['state']
-    }
-  : [Config['modules']] extends [undefined]
-    ? Config['state']
-    : Config['state'] &
-        {
-          [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-            Config['modules'],
-            { state: {} }
-          >[P]['state']
-        }
+export type TState<Config extends Configuration> = Config['state']
 
-export type TEffects<Config extends Configuration> = [
-  Config['effects']
-] extends [undefined]
-  ? {
-      [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
-        Config['modules'],
-        { effects: object }
-      >[P]['effects']
-    }
-  : [Config['modules']] extends [undefined]
-    ? Config['effects']
-    : Config['effects'] &
-        {
-          [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
-            Config['modules'],
-            { effects: object }
-          >[P]['effects']
-        }
+export type TEffects<Config extends Configuration> = Config['effects']
 
 export type Mutate<Value = any> = (state: IApp['state'], value: Value) => void
 
@@ -131,8 +90,8 @@ export type Action<InitialValue = void, ReturnValue = any> = Compose<
 
 export type TAction<
   InitialValue,
-  ReturnValue,
-  App extends { state: any; effects: any }
+  ReturnValue = InitialValue,
+  App extends { state: any; effects: any } = { state: any; effects: any }
 > = Compose<
   App['state'],
   App['effects'] & { state: App['state'] },
@@ -172,56 +131,10 @@ export type Compute<Input, Output> = (
 ) => (state: IApp['state']) => Output
 
 export type TConfig<Config extends Configuration> = {
-  state: [Config['state']] extends [undefined]
-    ? {
-        [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-          Config['modules'],
-          { state: {} }
-        >[P]['state']
-      }
-    : [Config['modules']] extends [undefined]
-      ? Config['state']
-      : Config['state'] &
-          {
-            [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
-              Config['modules'],
-              { state: {} }
-            >[P]['state']
-          }
-  effects: [Config['effects']] extends [undefined]
-    ? {
-        [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
-          Config['modules'],
-          { effects: object }
-        >[P]['effects']
-      }
-    : [Config['modules']] extends [undefined]
-      ? Config['effects']
-      : Config['effects'] &
-          {
-            [P in keyof SubType<
-              Config['modules'],
-              { effects: object }
-            >]: SubType<Config['modules'], { effects: object }>[P]['effects']
-          }
-  actions: [Config['actions']] extends [undefined]
-    ? {
-        [P in keyof SubType<Config['modules'], { actions: object }>]: SubType<
-          Config['modules'],
-          { actions: object }
-        >[P]['actions']
-      }
-    : [Config['modules']] extends [undefined]
-      ? Config['actions']
-      : Config['actions'] &
-          {
-            [P in keyof SubType<
-              Config['modules'],
-              { actions: object }
-            >]: SubType<Config['modules'], { actions: object }>[P]['actions']
-          }
+  state: Config['state'] & {}
+  effects: Config['effects'] & {}
+  actions: Config['actions'] & {}
   reactions: any
-  namespaces: any
 }
 
 export type TActionCreator<App> = {
@@ -268,10 +181,6 @@ export default class App<
       }
     }
 
-    /*
-      Mutate module functions into module objects
-    */
-    this.mutateModuleFunctionsIntoModules(configuration)
     /*
       Set up an eventHub to trigger information from derived, computed and reactions
     */
@@ -352,36 +261,11 @@ export default class App<
     this.proxyStateTree = proxyStateTree
     this.eventHub = eventHub
 
-    const initializers = this.getInitializers(configuration)
-
-    if (!initializers.length) {
-      return
-    }
-
-    const rootInitializer =
-      initializers[0].name === 'onInitialize' ? initializers.shift() : null
-
-    let onInitialize
-
-    if (initializers.length) {
-      onInitialize = operators.parallel(initializers)
-    }
-
-    if (rootInitializer) {
-      onInitialize = operators.compose(rootInitializer)
-    }
-
-    // @ts-ignore
-    onInitialize.displayName = 'onInitialize'
-    onInitialize(undefined)
-  }
-  private mutateModuleFunctionsIntoModules(config: Configuration) {
-    if (config.modules) {
-      Object.keys(config.modules).forEach((key) => {
-        if (typeof config.modules[key] === 'function') {
-          config.modules[key] = (config.modules[key] as any)(key)
-        }
-      })
+    if (configuration.onInitialize) {
+      const onInitialize = operators.compose(configuration.onInitialize)
+      // @ts-ignore
+      onInitialize.displayName = 'onInitialize'
+      onInitialize(undefined)
     }
   }
   private initializeDevtools(host, actionChain, eventHub, proxyStateTree) {
@@ -492,43 +376,13 @@ export default class App<
       reaction.create(reactions[name][0], reactions[name][1])
     })
   }
-  private getState(configuration) {
+  private getState(configuration: Configuration) {
     let state = {}
     if (configuration.state) {
       state = this.processState(configuration.state)
     }
-    if (configuration.modules) {
-      Object.keys(configuration.modules).reduce((aggr, key) => {
-        if (configuration.modules[key].state) {
-          return Object.assign(aggr, {
-            [key]: this.processState(configuration.modules[key].state),
-          })
-        }
-
-        return aggr
-      }, state)
-    }
 
     return state
-  }
-  private getInitializers(configuration) {
-    let initializers = []
-    if (configuration.onInitialize) {
-      initializers.push(configuration.onInitialize)
-    }
-    if (configuration.modules) {
-      initializers = Object.keys(configuration.modules).reduce((aggr, key) => {
-        if (configuration.modules[key].onInitialize) {
-          configuration.modules[key].onInitialize.displayName =
-            key + '.onInitialize'
-          return aggr.concat(configuration.modules[key].onInitialize)
-        }
-
-        return aggr
-      }, initializers)
-    }
-
-    return initializers
   }
   private processState(state: {}) {
     return Object.keys(state).reduce((aggr, key) => {
@@ -544,21 +398,10 @@ export default class App<
       return aggr
     }, {})
   }
-  private getActions(configuration, operators) {
+  private getActions(configuration: Configuration, operators) {
     let actions = {}
     if (configuration.actions) {
       actions = configuration.actions
-    }
-    if (configuration.modules) {
-      Object.keys(configuration.modules).reduce((aggr, key) => {
-        if (configuration.modules[key].actions) {
-          return Object.assign(aggr, {
-            [key]: configuration.modules[key].actions,
-          })
-        }
-
-        return aggr
-      }, actions)
     }
 
     const evaluatedActions = Object.keys(actions).reduce((aggr, name) => {

--- a/packages/node_modules/overmind/src/modules.ts
+++ b/packages/node_modules/overmind/src/modules.ts
@@ -1,0 +1,132 @@
+import { Action, Configuration } from './'
+
+type SubType<Base, Condition> = Pick<
+  Base,
+  { [Key in keyof Base]: Base[Key] extends Condition ? Key : never }[keyof Base]
+>
+
+interface ConfigurationWithModules extends Configuration {
+  modules?: {
+    [namespace: string]: {
+      onInitialize?: any
+      state?: any
+      effects?: any
+      actions?: any
+      reactions?: any
+    }
+  }
+}
+
+type TState<Config extends ConfigurationWithModules> = [
+  Config['state']
+] extends [undefined]
+  ? {
+      [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
+        Config['modules'],
+        { state: {} }
+      >[P]['state']
+    }
+  : [Config['modules']] extends [undefined]
+    ? Config['state']
+    : Config['state'] &
+        {
+          [P in keyof SubType<Config['modules'], { state: {} }>]: SubType<
+            Config['modules'],
+            { state: {} }
+          >[P]['state']
+        }
+
+type TEffects<Config extends ConfigurationWithModules> = [
+  Config['effects']
+] extends [undefined]
+  ? {
+      [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
+        Config['modules'],
+        { effects: object }
+      >[P]['effects']
+    }
+  : [Config['modules']] extends [undefined]
+    ? Config['effects']
+    : Config['effects'] &
+        {
+          [P in keyof SubType<Config['modules'], { effects: object }>]: SubType<
+            Config['modules'],
+            { effects: object }
+          >[P]['effects']
+        }
+
+type TActions<Config extends ConfigurationWithModules> = [
+  Config['actions']
+] extends [undefined]
+  ? {
+      [P in keyof SubType<Config['modules'], { actions: object }>]: SubType<
+        Config['modules'],
+        { actions: object }
+      >[P]['actions']
+    }
+  : [Config['modules']] extends [undefined]
+    ? Config['actions']
+    : Config['actions'] &
+        {
+          [P in keyof SubType<Config['modules'], { actions: object }>]: SubType<
+            Config['modules'],
+            { actions: object }
+          >[P]['actions']
+        }
+
+function parseModule(
+  result: { actions: any; effects: any; state: any; initializers: any[] },
+  modName: string,
+  mod: Configuration | Function
+) {
+  const { actions, effects, onInitialize, state }: Configuration =
+    typeof mod === 'function' ? mod(modName) : mod
+  if (actions) {
+    result.actions[modName] = actions
+  }
+  if (effects) {
+    result.effects[modName] = effects
+  }
+  if (state) {
+    result.state[modName] = state
+  }
+  if (onInitialize) {
+    // @ts-ignore
+    onInitialize.displayName = modName + '.onInitialize'
+    result.initializers.push(onInitialize)
+  }
+}
+
+export function modules<T extends ConfigurationWithModules>(
+  configWithModules: T
+): {
+  onInitialize?: any
+  state: TState<T>
+  effects: TEffects<T>
+  actions: TActions<T>
+} {
+  const result: any = {
+    initializers: [],
+    actions: configWithModules.actions || {},
+    effects: configWithModules.effects || {},
+    state: configWithModules.state || {},
+  }
+  const modules = configWithModules.modules || {}
+
+  Object.keys(modules).forEach((modName) => {
+    parseModule(result, modName, modules[modName])
+  })
+
+  const onInitialize: Action<undefined> = configWithModules.onInitialize
+    ? configWithModules.onInitialize
+    : (action) => action.parallel(result.initializers)
+
+  // @ts-ignore
+  onInitialize.displayName = 'onInitialize'
+  return {
+    onInitialize,
+    actions: result.actions,
+    effects: result.effects,
+    state: result.state,
+  }
+}


### PR DESCRIPTION
this greatly simplifies the types

BREAKING CHANGE:

modules are now supported by the "modules" function

Replaces PR #102 

```ts
const config = modules({
  state: {...},
  actions: {...},
  modules {
    foo: {...},
    bar: {...},
  }
})
```