### PR TITLE
feat(proxy-state-tree): export PATH so that external libraries can us it

### DIFF
--- a/packages/node_modules/proxy-state-tree/src/index.ts
+++ b/packages/node_modules/proxy-state-tree/src/index.ts
@@ -1,4 +1,4 @@
-import proxify, { IS_PROXY, STATUS } from './proxify'
+import proxify, { IS_PROXY, PATH, STATUS } from './proxify'
 const isPlainObject = require('is-plain-object')
 
 export type Options = {
@@ -197,5 +197,5 @@ class ProxyStateTree {
   }
 }
 
-export { IS_PROXY }
+export { IS_PROXY, PATH }
 export default ProxyStateTree


### PR DESCRIPTION
This is useful for libraries doing introspection (in testing, storybook display, error handling).