### PR TITLE
fix(overmind): fix onInitialize to use the same api as other actions

### DIFF
--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import App, { TAction, TConfig, modules } from './'
+import App, { Action, TAction, TConfig, modules } from './'
 
 describe('Overmind', () => {
   test('should instantiate app with state', () => {
@@ -15,12 +15,22 @@ describe('Overmind', () => {
     expect(app.state.foo).toEqual('bar')
   })
   test('should instantiate app with onInitialize', () => {
-    const app = new App({
-      onInitialize: (app) => {
-        expect(app.state.foo).toBe('bar')
-        expect(typeof app.actions.doThis === 'function')
+    interface AppType {
+      state: {
+        foo: string
+      }
+      actions: {
+        doThis(): void
+      }
+    }
+    const onInitialize: Action<AppType, string> = (action) =>
+      action.map(({ value }) => {
+        expect(value.state.foo).toBe('bar')
+        expect(typeof value.actions.doThis === 'function')
         return 'foo'
-      },
+      })
+    const app = new App({
+      onInitialize,
       state: {
         foo: 'bar',
       },
@@ -87,25 +97,26 @@ describe('Overmind', () => {
     expect(app.actions.bar.bar('bop')).toEqual('bop')
   })
   test('should instantiate modules with onInitialize', () => {
+    const result = []
     const app = new App(
       modules({
         modules: {
           foo: {
-            onInitialize: () => {
-              return 'foo'
+            onInitialize: (action) => () => {
+              result.push('foo')
             },
           },
           bar: {
-            onInitialize: () => {
-              return 'bar'
+            onInitialize: (action) => () => {
+              result.push('bar')
             },
           },
         },
       })
     )
 
-    return app.initialized.then((values) => {
-      expect(values).toEqual(['foo', 'bar'])
+    return app.initialized.then(() => {
+      expect(result).toEqual(['foo', 'bar'])
     })
   })
 })

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -12,6 +12,7 @@ import Derived from './derived'
 import Devtools, { Message, safeValue } from './Devtools'
 import { EventType, Events, Options } from './internalTypes'
 import Reaction from './reaction'
+
 const isPlainObject = require('is-plain-object')
 
 export { modules } from './modules'
@@ -275,9 +276,13 @@ export default class App<
     this.proxyStateTree = proxyStateTree
     this.eventHub = eventHub
 
-    this.initialized = Promise.resolve(
-      configuration.onInitialize ? configuration.onInitialize(this) : null
-    )
+    if (configuration.onInitialize) {
+      const onInitialize = configuration.onInitialize(operators)
+      onInitialize.displayName = 'onInitialize'
+      this.initialized = Promise.resolve(onInitialize(this))
+    } else {
+      this.initialized = Promise.resolve(null)
+    }
   }
   private initializeDevtools(host, actionChain, eventHub, proxyStateTree) {
     const devtools = new Devtools(

--- a/packages/node_modules/overmind/src/modules.ts
+++ b/packages/node_modules/overmind/src/modules.ts
@@ -111,18 +111,15 @@ export function modules<T extends ConfigurationWithModules>(
   }
   const modules = configWithModules.modules || {}
 
+  if (configWithModules.onInitialize) {
+    result.initilizers.push(configWithModules.onInitialize)
+  }
+
   Object.keys(modules).forEach((modName) => {
     parseModule(result, modName, modules[modName])
   })
 
-  const onInitialize = (app) => {
-    const allInitializers = [
-      configWithModules.onInitialize && configWithModules.onInitialize(app),
-      ...result.initializers.map((initializer) => initializer(app)),
-    ].filter((initializer) => !!initializer)
-
-    return Promise.all(allInitializers)
-  }
+  const onInitialize = (action) => action.parallel(result.initializers)
 
   return {
     onInitialize,


### PR DESCRIPTION
It is more powerful and removes confusion as some actions in `config` are callbacks and others use operators. I think this also helps with the devtools.