### PR TITLE
refactor(overmind): use TConfig instead of TApp

### DIFF
--- a/packages/demos/react-typescript-todomvc/src/app/actions.ts
+++ b/packages/demos/react-typescript-todomvc/src/app/actions.ts
@@ -1,5 +1,4 @@
 import * as React from 'react'
-
 import { Action } from './'
 import * as mutations from './mutations'
 import * as operations from './operations'

--- a/packages/demos/react-typescript-todomvc/src/app/index.ts
+++ b/packages/demos/react-typescript-todomvc/src/app/index.ts
@@ -1,6 +1,6 @@
 import App, {
   TAction,
-  TApp,
+  TConfig,
   TContext,
   TDerive,
   TMutate,
@@ -12,7 +12,7 @@ import * as actions from './actions'
 import * as context from './context'
 import * as state from './state'
 
-const config = {
+export const config = {
   context,
   actions,
   state,
@@ -24,32 +24,36 @@ export type Connect = TConnect<typeof app>
 
 export const connect = createConnect(app)
 
-type IApp = TApp<typeof config>
+/*
+  OVERMIND TYPES
+*/
 
-export default app
-
-// ==== The following types are copied from overmind documentation ====
+type Config = TConfig<typeof config>
 
 export type Action<Value = void, ReturnValue = Value> = TAction<
-  IApp,
+  Config,
   Value,
   ReturnValue
 >
 
-export type Mutate<Value = any> = TMutate<IApp, Value>
+export type Mutate<Value = any> = TMutate<Config, Value>
 
-export type Context<Value> = TContext<IApp, Value>
+export type Context<Value> = TContext<Config, Value>
 
-// Operations
 export type Map<Value, ReturnValue = Value> = (
   ctx: Context<Value>
 ) => ReturnValue
+
 export type Filter<Value = any> = (ctx: Context<Value>) => boolean
+
 export type When<Value = any> = (ctx: Context<Value>) => boolean
+
 export type Run<Value = any> = (ctx: Context<Value>) => void
+
 export type Fork<Value = any> = (ctx: Context<Value>) => string
+
 export type Attempt<Value, ReturnValue> = (ctx: Context<Value>) => ReturnValue
 
-export type Derive<Value> = TDerive<IApp, Value>
+export type Derive<Value> = TDerive<Config, Value>
 
-export type Reaction = TReaction<IApp>
+export type Reaction = TReaction<Config>

--- a/packages/node_modules/overmind/src/derived.test.ts
+++ b/packages/node_modules/overmind/src/derived.test.ts
@@ -1,4 +1,4 @@
-import App, { TAction, TApp, TDerive } from './'
+import App, { TAction, TConfig, TDerive } from './'
 
 type State = {
   foo: string
@@ -16,11 +16,11 @@ describe('Derived', () => {
       state,
     }
 
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: typeof state
     }>
 
-    type Derive<Value> = TDerive<IApp, Value>
+    type Derive<Value> = TDerive<Config, Value>
 
     const app = new App(config)
 
@@ -43,15 +43,15 @@ describe('Derived', () => {
         changeFoo,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: {
         foo: string
         upperFoo: string
       }
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
-    type Derive<Value> = TDerive<IApp, Value>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
+    type Derive<Value> = TDerive<Config, Value>
 
     const app = new App(config)
     function render() {
@@ -86,15 +86,15 @@ describe('Derived', () => {
         changeFoo,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: {
         foo: string
         upperFoo: string
       }
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
-    type Derive<Value> = TDerive<IApp, Value>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
+    type Derive<Value> = TDerive<Config, Value>
 
     const app = new App(config)
     app.actions.changeFoo()

--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import App, { Action, TAction, TApp, modules } from './'
+import App, { Action, TAction, TConfig, modules } from './'
 
 describe('Overmind', () => {
   test('should instantiate app with state', () => {
@@ -74,7 +74,7 @@ describe('Overmind', () => {
       },
     })
 
-    type App = TApp<{
+    type Config = TConfig<{
       state: {
         foo: typeof config.state.foo
         bar: typeof config.state.bar
@@ -87,7 +87,7 @@ describe('Overmind', () => {
         bar: typeof config.actions.bar
       }
     }>
-    type Action<Input = void, Output = any> = TAction<App, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
 
     const app = new App(config)
 
@@ -135,10 +135,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
 
     const app = new App(config)
 
@@ -156,13 +156,13 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: {
         foo: string
       }
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
 
     const app = new App(config)
 
@@ -190,7 +190,7 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: {
         foo: string
       }
@@ -199,7 +199,7 @@ describe('OPERATORS', () => {
       }
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
 
     const app = new App(config)
     return app.actions
@@ -217,10 +217,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
 
     const app = new App(config)
 
@@ -239,10 +239,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
 
     return Promise.resolve(app.actions.doThis()).then((value) => {
@@ -262,10 +262,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
     return Promise.resolve(app.actions.doThis()).then((value) => {
       expect(value).toBe('bar')
@@ -283,10 +283,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
     expect(app.actions.doThis()).toBe('foo')
   })
@@ -303,10 +303,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
 
     expect(app.actions.doThis()).toBe('bar')
@@ -321,10 +321,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
     expect(app.actions.doThis('foo')).toBe('bar')
   })
@@ -337,10 +337,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
 
     expect(app.actions.doThis('foo')).toEqual({ value: 'foo' })
@@ -360,10 +360,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
 
     return Promise.resolve(app.actions.doThis()).then((value) => {
@@ -383,10 +383,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
     app.actions.doThis()
     expect(mockCallback.mock.calls.length).toBe(1)
@@ -403,10 +403,10 @@ describe('OPERATORS', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       actions: typeof config.actions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
     const app = new App(config)
     app.actions.doThis()
     expect(mockCallback.mock.calls.length).toBe(1)

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -7,7 +7,7 @@ import Derived from './derived'
 import Devtools, { Message, safeValue } from './Devtools'
 import { EventType, Events, Options } from './internalTypes'
 import Reaction from './reaction'
-import { BaseApp, Configuration, TApp } from './types'
+import { BaseApp, Configuration, TConfig } from './types'
 
 export * from './types'
 
@@ -25,10 +25,10 @@ export default class App<Config extends Configuration> implements BaseApp {
   initialized: Promise<any>
   eventHub: EventEmitter<Events>
   devtools: Devtools
-  actions: TApp<Config>['actions']
-  state: TApp<Config>['state']
+  actions: TConfig<Config>['actions']
+  state: TConfig<Config>['state']
   // We add the context here so that App implements BaseApp (makes types simpler).
-  context: TApp<Config>['context'] & { state: TApp<Config>['state'] }
+  context: TConfig<Config>['context'] & { state: TConfig<Config>['state'] }
   constructor(configuration: Config, options: Options = {}) {
     const name = options.name || 'MyApp'
 
@@ -313,7 +313,7 @@ export default class App<Config extends Configuration> implements BaseApp {
     return {
       add(
         name: string,
-        stateCb: (state: TApp<Config>['state']) => any,
+        stateCb: (state: TConfig<Config>['state']) => any,
         cb: Function
       ) {
         const reaction = new Reaction(

--- a/packages/node_modules/overmind/src/reaction.test.ts
+++ b/packages/node_modules/overmind/src/reaction.test.ts
@@ -1,4 +1,4 @@
-import App, { TAction, TApp, TReaction } from './'
+import App, { TAction, TConfig, TReaction } from './'
 
 describe('Reaction', () => {
   test('should instantiate app with reactions', () => {
@@ -23,15 +23,15 @@ describe('Reaction', () => {
         react,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: {
         foo: string
       }
       actions: typeof config.actions
       reactions: typeof config.reactions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
-    type Reaction = TReaction<IApp>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
+    type Reaction = TReaction<Config>
     const app = new App(config)
 
     app.actions.foo()
@@ -63,15 +63,15 @@ describe('Reaction', () => {
         react,
       },
     }
-    type IApp = TApp<{
+    type Config = TConfig<{
       state: {
         foo: typeof config.state.foo
       }
       actions: typeof config.actions
       reactions: typeof config.reactions
     }>
-    type Action<Input = void, Output = any> = TAction<IApp, Input, Output>
-    type Reaction = TReaction<IApp>
+    type Action<Input = void, Output = any> = TAction<Config, Input, Output>
+    type Reaction = TReaction<Config>
     const app = new App(config)
     app.actions.foo()
     expect(hasRunReaction).toBe(true)

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -19,7 +19,7 @@ export type BaseApp = {
   actions: {}
 }
 
-export interface TApp<Config extends Configuration> {
+export interface TConfig<Config extends Configuration> {
   // Resolves `Derive` types in state.
   state: ResolveState<Config['state'] & {}>
   // Transform actions into callable functions.


### PR DESCRIPTION
By changing `TApp` to `TConfig` we get a bit cleaner setup of the app. I like the idea of putting the types in the `index` file, though `TApp` conflicts with the `App` constructor.

So now you say:

```ts
import App, { TConfig } from 'overmind'

const config = {
  state: {}
}

type Config = TConfig<typeof config>

const app = new App(config)
```

No conflict and you are really typing up the configuration of the app, not the instance. So I think keeping "App" out of the picture until instantiation is a good thing :)

Have not refactored devtools here

