### PR TITLE
feat(overmind): allow proxies in object value passed to action

### DIFF
--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Overmind, TAction, TApp, EventType } from './'
+import { EventType, Overmind, TAction, TApp } from './'
 import { modules } from './modules'
 
 function toJSON(obj) {
@@ -30,12 +30,21 @@ function createDefaultApp() {
   const changeValue: Action<{ isAwesome: boolean }> = (context) => {
     context.value.isAwesome = !context.value.isAwesome
   }
+  const changeFormValue: Action<{
+    key: string
+    form: { [key: string]: any }
+    value: any
+  }> = (context) => {
+    const { form, key, value } = context.value
+    form[key] = value
+  }
   const actions = {
+    asyncChangeFoo,
+    changeFormValue,
     changeFoo,
     changeFooWithEffect,
-    waitAndChangeFoo,
-    asyncChangeFoo,
     changeValue,
+    waitAndChangeFoo,
   }
   const effects = {
     hello() {
@@ -184,7 +193,7 @@ describe('Overmind', () => {
     const app = createDefaultApp()
     app.eventHub.once(EventType.MUTATIONS, (data) => {
       expect(toJSON(data)).toEqual({
-        actionId: 0,
+        actionId: 2,
         actionName: 'changeFoo',
         mutations: [
           {
@@ -205,7 +214,7 @@ describe('Overmind', () => {
     const app = createDefaultApp()
     app.eventHub.on(EventType.MUTATIONS, (data) => {
       expect(toJSON(data)).toEqual({
-        actionId: 2,
+        actionId: 5,
         actionName: 'waitAndChangeFoo',
         mutations: [
           {
@@ -226,7 +235,7 @@ describe('Overmind', () => {
     const app = createDefaultApp()
     app.eventHub.on(EventType.MUTATIONS, (data) => {
       expect(toJSON(data)).toEqual({
-        actionId: 3,
+        actionId: 0,
         actionName: 'asyncChangeFoo',
         mutations: [
           {
@@ -303,6 +312,18 @@ describe('Overmind', () => {
     expect.assertions(2)
     const app = createDefaultApp()
     expect(() => app.actions.changeValue(app.state.item)).not.toThrow()
+    expect(app.state.item.isAwesome).toBe(false)
+  })
+  test('should allow mutations on passed values in object', () => {
+    expect.assertions(2)
+    const app = createDefaultApp()
+    expect(() =>
+      app.actions.changeFormValue({
+        form: app.state.item,
+        key: 'isAwesome',
+        value: false,
+      })
+    ).not.toThrow()
     expect(app.state.item.isAwesome).toBe(false)
   })
 })

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'betsy'
-import { ProxyStateTree } from 'proxy-state-tree'
+import { IS_PROXY, ProxyStateTree } from 'proxy-state-tree'
+
 import { Derived } from './derived'
 import { Devtools, Message, safeValue } from './Devtools'
 import {
@@ -9,17 +10,17 @@ import {
   ResolveActions,
   ResolveState,
 } from './internalTypes'
+import { proxifyEffects } from './proxyfyEffects'
 import { Reaction } from './reaction'
 import {
   BaseApp,
   Configuration,
-  TDerive,
-  TReaction,
   TAction,
   TContext,
+  TDerive,
   TOperator,
+  TReaction,
 } from './types'
-import { proxifyEffects } from './proxyfyEffects'
 
 export * from './types'
 
@@ -179,6 +180,24 @@ export class Overmind<Config extends Configuration> implements BaseApp {
       this.trackEffects(this.effects, execution)
     )
   }
+  private scopeValue(scopedTree: ProxyStateTree, value: any) {
+    if (!value) {
+      return value
+    }
+    if (value[IS_PROXY]) {
+      return scopedTree.scope(value)
+    } else if (typeof value === 'object') {
+      return Object.assign(
+        {},
+        ...Object.keys(value).map((key) => ({
+          [key]: scopedTree.scope(value[key]),
+        }))
+      )
+    } else {
+      return value
+    }
+  }
+
   private createAction(name, action) {
     this.actionReferences.push(action)
     return (value?) => {
@@ -212,7 +231,7 @@ export class Overmind<Config extends Configuration> implements BaseApp {
         scopedTree.startMutationTracking()
         const result = action(
           this.createContext(
-            scopedTree.scope(value),
+            this.scopeValue(scopedTree, value),
             execution,
             scopedTree.get()
           )

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -186,7 +186,7 @@ export class Overmind<Config extends Configuration> implements BaseApp {
     }
     if (value[IS_PROXY]) {
       return scopedTree.scope(value)
-    } else if (typeof value === 'object') {
+    } else if (isPlainObject(value)) {
       return Object.assign(
         {},
         ...Object.keys(value).map((key) => ({


### PR DESCRIPTION
Passing an object as argument to an action is a common pattern and we should allow passing part of the state tree and have tracking/mutations work there:

```html
<Field form={app.state.form.login} key="username" />
```

```ts
app.actions.form.changeValue({form, key, value}) // form and key are props
```