### PR TITLE
fix(overmind): fix actions type resolution when actions are missing in config

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -4,8 +4,8 @@ import { IS_PROXY, ProxyStateTree } from 'proxy-state-tree'
 import { Derived } from './derived'
 import { Devtools, Message, safeValue } from './Devtools'
 import {
-  EventType,
   Events,
+  EventType,
   Options,
   ResolveActions,
   ResolveState,
@@ -63,8 +63,8 @@ export class Overmind<Config extends Configuration> implements BaseApp {
   eventHub: EventEmitter<Events>
   devtools: Devtools
   actions: ResolveActions<Config['actions']>
-  state: ResolveState<Config['state']>
-  effects: Config['effects']
+  state: ResolveState<Config['state'] & {}>
+  effects: Config['effects'] & {}
   constructor(configuration: Config, options: Options = {}) {
     const name = options.name || 'MyApp'
 

--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -1,5 +1,5 @@
-import { BaseApp, TDerive, TAction, TOperator } from './types'
 import { Mutation } from '../../proxy-state-tree'
+import { BaseApp, TAction, TDerive, TOperator } from './types'
 
 export type SubType<Base, Condition> = Pick<
   Base,
@@ -135,9 +135,11 @@ type TOperationValue<T> = T extends (
   ? (TContext extends { value: infer TValue } ? TValue : never)
   : never
 
-type NestedActions = {
-  [key: string]: TAction<any, any> | TOperator<any, any> | NestedActions
-}
+type NestedActions =
+  | {
+      [key: string]: TAction<any, any> | TOperator<any, any> | NestedActions
+    }
+  | undefined
 
 export type ResolveActions<Actions extends NestedActions> = {
   [T in keyof Actions]: Actions[T] extends TAction<any, any>

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -21,10 +21,10 @@ export type BaseApp = {
 
 export interface TApp<Config extends Configuration> {
   // Resolves `Derive` types in state.
-  state: ResolveState<Config['state']>
+  state: ResolveState<Config['state'] & {}>
   // Transform actions into callable functions.
   actions: ResolveActions<Config['actions']>
-  effects: [Config['effects']] extends [void] ? {} : Config['effects']
+  effects: Config['effects'] & {}
 }
 
 export type TContext<App extends BaseApp, Value> = TBaseContext<App> & {


### PR DESCRIPTION
This fixes these error messages:

```
(12,140): Type 'App' does not satisfy the constraint 'BaseApp'.
  Type 'Overmind<Configuration>' is not assignable to type 'BaseApp'.
    Types of property 'state' are incompatible.
      Type 'ResolveState<{}> | undefined' is not assignable to type '{}'.
        Type 'undefined' is not assignable to type '{}'.
```