### PR TITLE
refactor overmind to simplify exposed types, use Config instead of App

### DIFF
--- a/packages/node_modules/overmind-devtools/src/app/index.ts
+++ b/packages/node_modules/overmind-devtools/src/app/index.ts
@@ -1,4 +1,4 @@
-import { Overmind, TApp } from 'overmind'
+import { Overmind, TConfig } from 'overmind'
 import { TConnect, createConnect } from 'overmind-react'
 
 import * as actions from './actions'
@@ -13,7 +13,7 @@ const config = {
 }
 
 declare module 'overmind' {
-  interface IApp extends TApp<typeof config> {}
+  interface IConfig extends TConfig<typeof config> {}
 }
 
 const app = new Overmind(config, {

--- a/packages/node_modules/overmind-devtools/src/app/operators.ts
+++ b/packages/node_modules/overmind-devtools/src/app/operators.ts
@@ -1,4 +1,4 @@
-import { mutate, forEach, fork, Operator, when, map, EventType } from 'overmind'
+import { mutate, forEach, fork, Operator, when, map } from 'overmind'
 import {
   Message,
   AppMessage,

--- a/packages/node_modules/overmind-react/src/index.test.tsx
+++ b/packages/node_modules/overmind-react/src/index.test.tsx
@@ -1,4 +1,4 @@
-import { Overmind, TAction, TApp } from 'overmind'
+import { Overmind, TAction } from 'overmind'
 import * as React from 'react'
 import * as renderer from 'react-test-renderer'
 
@@ -19,18 +19,18 @@ describe('React', () => {
       },
     }
 
-    type IApp = TApp<{
+    type IConfig = {
       state: {
         foo: typeof config.state.foo
       }
       actions: {
         doThis: typeof doThis
       }
-    }>
+    }
 
     const app = new Overmind(config)
 
-    type Action<Input = void> = TAction<IApp, Input>
+    type Action<Input = void> = TAction<IConfig, Input>
 
     const connect = createConnect(app)
 
@@ -58,18 +58,18 @@ describe('React', () => {
       },
     }
 
-    type IApp = TApp<{
+    type IConfig = {
       state: {
         foo: typeof config.state.foo
       }
       actions: {
         doThis: typeof doThis
       }
-    }>
+    }
 
     const app = new Overmind(config)
 
-    type Action<Input = void> = TAction<IApp, Input>
+    type Action<Input = void> = TAction<IConfig, Input>
 
     const connect = createConnect(app)
 
@@ -130,18 +130,18 @@ describe('React', () => {
         doThis,
       },
     }
-    type IApp = TApp<{
+    type IConfig = {
       state: {
         foo: typeof config.state.foo
       }
       actions: {
         doThis: typeof doThis
       }
-    }>
+    }
 
     const app = new Overmind(config)
 
-    type Action<Input = void> = TAction<IApp, Input>
+    type Action<Input = void> = TAction<IConfig, Input>
 
     const connect = createConnect(app)
 

--- a/packages/node_modules/overmind/src/derived.test.ts
+++ b/packages/node_modules/overmind/src/derived.test.ts
@@ -1,4 +1,4 @@
-import { Overmind, TAction, TApp, TDerive } from './'
+import { Overmind, TAction, TDerive } from './'
 
 type State = {
   foo: string
@@ -19,11 +19,11 @@ describe('Derived', () => {
       state,
     }
 
-    type IApp = TApp<{
+    type Config = {
       state: typeof state
-    }>
+    }
 
-    type Derive<Parent extends object, Value> = TDerive<IApp, Parent, Value>
+    type Derive<Parent extends object, Value> = TDerive<Config, Parent, Value>
 
     const app = new Overmind(config)
 
@@ -48,15 +48,15 @@ describe('Derived', () => {
         changeFoo,
       },
     }
-    type IApp = TApp<{
+    type Config = {
       state: {
         foo: string
         upperFoo: string
       }
       actions: typeof config.actions
-    }>
-    type Action<Input = void> = TAction<IApp, Input>
-    type Derive<Parent extends object, Value> = TDerive<IApp, Parent, Value>
+    }
+    type Action<Input = void> = TAction<Config, Input>
+    type Derive<Parent extends object, Value> = TDerive<Config, Parent, Value>
 
     const app = new Overmind(config)
     function render() {
@@ -92,15 +92,15 @@ describe('Derived', () => {
         changeFoo,
       },
     }
-    type IApp = TApp<{
+    type Config = {
       state: {
         foo: string
         upperFoo: string
       }
       actions: typeof config.actions
-    }>
-    type Action<Input = void> = TAction<IApp, Input>
-    type Derive<Parent extends object, Value> = TDerive<IApp, Parent, Value>
+    }
+    type Action<Input = void> = TAction<Config, Input>
+    type Derive<Parent extends object, Value> = TDerive<Config, Parent, Value>
 
     const app = new Overmind(config)
 
@@ -125,15 +125,15 @@ describe('Derived', () => {
         changeFoo,
       },
     }
-    type IApp = TApp<{
+    type Config = {
       state: {
         foo: string
         upperFoo: string
       }
       actions: typeof config.actions
-    }>
-    type Action<Input = void> = TAction<IApp, Input>
-    type Derive<Parent extends object, Value> = TDerive<IApp, Parent, Value>
+    }
+    type Action<Input = void> = TAction<Config, Input>
+    type Derive<Parent extends object, Value> = TDerive<Config, Parent, Value>
 
     const app = new Overmind(config)
 

--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import { EventType, Overmind, TAction, TApp } from './'
+import { EventType, Overmind, TAction } from './'
 import { namespaced } from './config'
 
 function toJSON(obj) {
@@ -60,12 +60,12 @@ function createDefaultApp() {
     effects,
   }
 
-  type App = TApp<{
+  type Config = {
     state: typeof state
     actions: typeof actions
     effects: typeof effects
-  }>
-  type Action<Value = void> = TAction<App, Value>
+  }
+  type Action<Value = void> = TAction<Config, Value>
 
   return new Overmind(config)
 }

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -12,9 +12,9 @@ import {
 import { proxifyEffects } from './proxyfyEffects'
 import { Reaction } from './reaction'
 import {
-  BaseApp,
   Configuration,
   TAction,
+  TConfig,
   TDerive,
   TOperator,
   TReaction,
@@ -27,21 +27,23 @@ export * from './types'
  * typing and then they can import `Action`,  `Operation` etc. directly from
  * overmind.
  */
-export interface IApp {}
+export interface IConfig {}
 
-type App = BaseApp & IApp
+type TheConfig = IConfig & TConfig<{ actions: {} }>
 
-export type Action<Value = void> = TAction<App, Value>
+export type Action<Value = void> = TAction<TheConfig, Value>
 
 export type Derive<Parent extends object, Value> = TDerive<
-  App,
-  ResolveState<Parent>,
+  TheConfig,
+  Parent,
   Value
 >
 
-export type Reaction = TReaction<App>
+export type Reaction = TReaction<TheConfig>
 
-export type OnInitialize = (context: TValueContext<App, App['actions']>) => void
+export type OnInitialize = (
+  context: TValueContext<TheConfig, ResolveActions<TheConfig['actions']>>
+) => void
 
 const isPlainObject = require('is-plain-object')
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
@@ -53,10 +55,10 @@ export const log = (...objects: any[]) =>
 
 const hotReloadingCache = {}
 
-// We do not use TApp<Config> directly to type the class in order to avoid
+// We do not use TConfig<Config> directly to type the class in order to avoid
 // the 'import(...)' function to be used in exported types.
 
-export class Overmind<Config extends Configuration> implements BaseApp {
+export class Overmind<Config extends Configuration> implements Configuration {
   private proxyStateTree: ProxyStateTree
   private actionReferences: Function[] = []
   private nextExecutionId: number = 0
@@ -67,7 +69,7 @@ export class Overmind<Config extends Configuration> implements BaseApp {
   state: ResolveState<Config['state'] & {}>
   effects: Config['effects'] & {}
   constructor(configuration: Config, options: Options = {}) {
-    const name = options.name || 'MyApp'
+    const name = options.name || 'MyConfig'
 
     if (IS_DEVELOPMENT) {
       if (hotReloadingCache[name]) {
@@ -477,46 +479,46 @@ export class Overmind<Config extends Configuration> implements BaseApp {
   OPERATORS
   needs to be in this file for typing override to work
 */
-export type Operator<Input, Output> = TOperator<App, Input, Output>
+export type Operator<Input, Output> = TOperator<TheConfig, Input, Output>
 
-export function pipe<App extends BaseApp, A, B, C>(
-  aOperator: TOperator<App, A, B>
-): TOperator<App, A, C>
+export function pipe<Config extends Configuration, A, B, C>(
+  aOperator: TOperator<Config, A, B>
+): TOperator<Config, A, C>
 
-export function pipe<App extends BaseApp, A, B, C, D>(
-  aOperator: TOperator<App, A, B>,
-  bOperator: TOperator<App, B, C>
-): TOperator<App, A, D>
+export function pipe<Config extends Configuration, A, B, C, D>(
+  aOperator: TOperator<Config, A, B>,
+  bOperator: TOperator<Config, B, C>
+): TOperator<Config, A, D>
 
-export function pipe<App extends BaseApp, A, B, C, D, E>(
-  aOperator: TOperator<App, A, B>,
-  bOperator: TOperator<App, B, C>,
-  cOperator: TOperator<App, C, D>
-): TOperator<App, A, E>
+export function pipe<Config extends Configuration, A, B, C, D, E>(
+  aOperator: TOperator<Config, A, B>,
+  bOperator: TOperator<Config, B, C>,
+  cOperator: TOperator<Config, C, D>
+): TOperator<Config, A, E>
 
-export function pipe<App extends BaseApp, A, B, C, D, E, F>(
-  aOperator: TOperator<App, A, B>,
-  bOperator: TOperator<App, B, C>,
-  cOperator: TOperator<App, C, D>,
-  dOperator: TOperator<App, D, E>
-): TOperator<App, A, F>
+export function pipe<Config extends Configuration, A, B, C, D, E, F>(
+  aOperator: TOperator<Config, A, B>,
+  bOperator: TOperator<Config, B, C>,
+  cOperator: TOperator<Config, C, D>,
+  dOperator: TOperator<Config, D, E>
+): TOperator<Config, A, F>
 
-export function pipe<App extends BaseApp, A, B, C, D, E, F, G>(
-  aOperator: TOperator<App, A, B>,
-  bOperator: TOperator<App, B, C>,
-  cOperator: TOperator<App, C, D>,
-  dOperator: TOperator<App, D, E>,
-  eOperator: TOperator<App, E, F>
-): TOperator<App, A, G>
+export function pipe<Config extends Configuration, A, B, C, D, E, F, G>(
+  aOperator: TOperator<Config, A, B>,
+  bOperator: TOperator<Config, B, C>,
+  cOperator: TOperator<Config, C, D>,
+  dOperator: TOperator<Config, D, E>,
+  eOperator: TOperator<Config, E, F>
+): TOperator<Config, A, G>
 
-export function pipe<App extends BaseApp, A, B, C, D, E, F, G, H>(
-  aOperator: TOperator<App, A, B>,
-  bOperator: TOperator<App, B, C>,
-  cOperator: TOperator<App, C, D>,
-  dOperator: TOperator<App, D, E>,
-  eOperator: TOperator<App, E, F>,
-  fOperator: TOperator<App, F, G>
-): TOperator<App, A, H>
+export function pipe<Config extends Configuration, A, B, C, D, E, F, G, H>(
+  aOperator: TOperator<Config, A, B>,
+  bOperator: TOperator<Config, B, C>,
+  cOperator: TOperator<Config, C, D>,
+  dOperator: TOperator<Config, D, E>,
+  eOperator: TOperator<Config, E, F>,
+  fOperator: TOperator<Config, F, G>
+): TOperator<Config, A, H>
 
 export function pipe(...operators) {
   const instance = (err, context, next, final = next) => {
@@ -628,9 +630,9 @@ function createNextPath(next) {
   }
 }
 
-export function map<Input, Output, TheApp extends BaseApp = App>(
-  operation: (input: TValueContext<TheApp, Input>) => Output
-): TOperator<TheApp, Input, Output extends Promise<infer U> ? U : Output> {
+export function map<Input, Output, Config extends Configuration = TheConfig>(
+  operation: (input: TValueContext<Config, Input>) => Output
+): TOperator<Config, Input, Output extends Promise<infer U> ? U : Output> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -646,9 +648,9 @@ export function map<Input, Output, TheApp extends BaseApp = App>(
   return instance
 }
 
-export function run<Input, TheApp extends BaseApp = App>(
-  operation: (input: TValueContext<TheApp, Input>) => any
-): TOperator<TheApp, Input, Input> {
+export function run<Input, Config extends Configuration = TheConfig>(
+  operation: (input: TValueContext<Config, Input>) => any
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -669,9 +671,12 @@ export function run<Input, TheApp extends BaseApp = App>(
   return instance
 }
 
-export function forEach<Input extends any[], TheApp extends BaseApp = App>(
-  forEachItemOperator: TOperator<TheApp, Input[0], any>
-): TOperator<TheApp, Input, Input> {
+export function forEach<
+  Input extends any[],
+  Config extends Configuration = TheConfig
+>(
+  forEachItemOperator: TOperator<Config, Input[0], any>
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -712,9 +717,9 @@ export function forEach<Input extends any[], TheApp extends BaseApp = App>(
   return instance
 }
 
-export function parallel<Input, TheApp extends BaseApp = App>(
-  operators: TOperator<TheApp, Input, any>[]
-): TOperator<TheApp, Input, Input> {
+export function parallel<Input, Config extends Configuration = TheConfig>(
+  operators: TOperator<Config, Input, any>[]
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -754,9 +759,9 @@ export function parallel<Input, TheApp extends BaseApp = App>(
   return instance
 }
 
-export function filter<Input, TheApp extends BaseApp = App>(
-  operation: (input: TValueContext<TheApp, Input>) => boolean
-): TOperator<TheApp, Input, Input> {
+export function filter<Input, Config extends Configuration = TheConfig>(
+  operation: (input: TValueContext<Config, Input>) => boolean
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next, final) => {
     if (err) next(err)
     else {
@@ -777,9 +782,9 @@ export function filter<Input, TheApp extends BaseApp = App>(
   return instance
 }
 
-export function mutate<Input, TheApp extends BaseApp = App>(
-  operation: (input: TValueContext<TheApp, Input>) => void
-): TOperator<TheApp, Input, Input> {
+export function mutate<Input, Config extends Configuration = TheConfig>(
+  operation: (input: TValueContext<Config, Input>) => void
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -803,12 +808,12 @@ export function mutate<Input, TheApp extends BaseApp = App>(
 
 export function fork<
   Input,
-  Paths extends { [key: string]: TOperator<TheApp, Input, any> },
-  TheApp extends BaseApp = App
+  Paths extends { [key: string]: TOperator<Config, Input, any> },
+  Config extends Configuration = TheConfig
 >(
-  operation: (input: TValueContext<TheApp, Input>) => keyof Paths,
+  operation: (input: TValueContext<Config, Input>) => keyof Paths,
   paths: Paths
-): TOperator<TheApp, Input, Input> {
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -834,13 +839,18 @@ export function fork<
   return instance
 }
 
-export function when<Input, OutputA, OutputB, TheApp extends BaseApp = App>(
-  operation: (input: TValueContext<TheApp, Input>) => boolean,
+export function when<
+  Input,
+  OutputA,
+  OutputB,
+  Config extends Configuration = TheConfig
+>(
+  operation: (input: TValueContext<Config, Input>) => boolean,
   paths: {
-    true: TOperator<TheApp, Input, OutputA>
-    false: TOperator<TheApp, Input, OutputB>
+    true: TOperator<Config, Input, OutputA>
+    false: TOperator<Config, Input, OutputB>
   }
-): TOperator<TheApp, Input, OutputA | OutputB> {
+): TOperator<Config, Input, OutputA | OutputB> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -871,9 +881,9 @@ export function when<Input, OutputA, OutputB, TheApp extends BaseApp = App>(
   return instance
 }
 
-export function wait<Input, TheApp extends BaseApp = App>(
+export function wait<Input, Config extends Configuration = TheConfig>(
   ms: number
-): TOperator<TheApp, Input, Input> {
+): TOperator<Config, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -887,9 +897,9 @@ export function wait<Input, TheApp extends BaseApp = App>(
   return instance
 }
 
-export function debounce<Input, TheApp extends BaseApp = App>(
+export function debounce<Input, Config extends Configuration = TheConfig>(
   ms: number
-): TOperator<TheApp, Input, Input> {
+): TOperator<Config, Input, Input> {
   let timeout
   let previousFinal
   const instance = (err, context, next, final) => {

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'betsy'
 import { IS_PROXY, ProxyStateTree } from 'proxy-state-tree'
-
 import { Derived } from './derived'
 import { Devtools, Message, safeValue } from './Devtools'
 import {
@@ -16,7 +15,6 @@ import {
   BaseApp,
   Configuration,
   TAction,
-  TContext,
   TDerive,
   TOperator,
   TReaction,
@@ -35,8 +33,6 @@ type App = BaseApp & IApp
 
 export type Action<Value = void> = TAction<App, Value>
 
-export type Context = TContext<App>
-
 export type Derive<Parent extends object, Value> = TDerive<
   App,
   ResolveState<Parent>,
@@ -45,9 +41,7 @@ export type Derive<Parent extends object, Value> = TDerive<
 
 export type Reaction = TReaction<App>
 
-export type OnInitialize = (
-  context: TValueContext<TContext<App>, App['actions']>
-) => void
+export type OnInitialize = (context: TValueContext<App, App['actions']>) => void
 
 const isPlainObject = require('is-plain-object')
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
@@ -483,46 +477,46 @@ export class Overmind<Config extends Configuration> implements BaseApp {
   OPERATORS
   needs to be in this file for typing override to work
 */
-export type Operator<Input, Output> = TOperator<Context, Input, Output>
+export type Operator<Input, Output> = TOperator<App, Input, Output>
 
-export function pipe<BaseContext, A, B, C>(
-  aOperator: TOperator<BaseContext, A, B>
-): TOperator<BaseContext, A, C>
+export function pipe<App extends BaseApp, A, B, C>(
+  aOperator: TOperator<App, A, B>
+): TOperator<App, A, C>
 
-export function pipe<BaseContext, A, B, C, D>(
-  aOperator: TOperator<BaseContext, A, B>,
-  bOperator: TOperator<BaseContext, B, C>
-): TOperator<BaseContext, A, D>
+export function pipe<App extends BaseApp, A, B, C, D>(
+  aOperator: TOperator<App, A, B>,
+  bOperator: TOperator<App, B, C>
+): TOperator<App, A, D>
 
-export function pipe<BaseContext, A, B, C, D, E>(
-  aOperator: TOperator<BaseContext, A, B>,
-  bOperator: TOperator<BaseContext, B, C>,
-  cOperator: TOperator<BaseContext, C, D>
-): TOperator<BaseContext, A, E>
+export function pipe<App extends BaseApp, A, B, C, D, E>(
+  aOperator: TOperator<App, A, B>,
+  bOperator: TOperator<App, B, C>,
+  cOperator: TOperator<App, C, D>
+): TOperator<App, A, E>
 
-export function pipe<BaseContext, A, B, C, D, E, F>(
-  aOperator: TOperator<BaseContext, A, B>,
-  bOperator: TOperator<BaseContext, B, C>,
-  cOperator: TOperator<BaseContext, C, D>,
-  dOperator: TOperator<BaseContext, D, E>
-): TOperator<BaseContext, A, F>
+export function pipe<App extends BaseApp, A, B, C, D, E, F>(
+  aOperator: TOperator<App, A, B>,
+  bOperator: TOperator<App, B, C>,
+  cOperator: TOperator<App, C, D>,
+  dOperator: TOperator<App, D, E>
+): TOperator<App, A, F>
 
-export function pipe<BaseContext, A, B, C, D, E, F, G>(
-  aOperator: TOperator<BaseContext, A, B>,
-  bOperator: TOperator<BaseContext, B, C>,
-  cOperator: TOperator<BaseContext, C, D>,
-  dOperator: TOperator<BaseContext, D, E>,
-  eOperator: TOperator<BaseContext, E, F>
-): TOperator<BaseContext, A, G>
+export function pipe<App extends BaseApp, A, B, C, D, E, F, G>(
+  aOperator: TOperator<App, A, B>,
+  bOperator: TOperator<App, B, C>,
+  cOperator: TOperator<App, C, D>,
+  dOperator: TOperator<App, D, E>,
+  eOperator: TOperator<App, E, F>
+): TOperator<App, A, G>
 
-export function pipe<BaseContext, A, B, C, D, E, F, G, H>(
-  aOperator: TOperator<BaseContext, A, B>,
-  bOperator: TOperator<BaseContext, B, C>,
-  cOperator: TOperator<BaseContext, C, D>,
-  dOperator: TOperator<BaseContext, D, E>,
-  eOperator: TOperator<BaseContext, E, F>,
-  fOperator: TOperator<BaseContext, F, G>
-): TOperator<BaseContext, A, H>
+export function pipe<App extends BaseApp, A, B, C, D, E, F, G, H>(
+  aOperator: TOperator<App, A, B>,
+  bOperator: TOperator<App, B, C>,
+  cOperator: TOperator<App, C, D>,
+  dOperator: TOperator<App, D, E>,
+  eOperator: TOperator<App, E, F>,
+  fOperator: TOperator<App, F, G>
+): TOperator<App, A, H>
 
 export function pipe(...operators) {
   const instance = (err, context, next, final = next) => {
@@ -634,9 +628,9 @@ function createNextPath(next) {
   }
 }
 
-export function map<Input, Output, BaseContext = Context>(
-  operation: (input: TValueContext<BaseContext, Input>) => Output
-): TOperator<BaseContext, Input, Output extends Promise<infer U> ? U : Output> {
+export function map<Input, Output, TheApp extends BaseApp = App>(
+  operation: (input: TValueContext<TheApp, Input>) => Output
+): TOperator<TheApp, Input, Output extends Promise<infer U> ? U : Output> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -652,9 +646,9 @@ export function map<Input, Output, BaseContext = Context>(
   return instance
 }
 
-export function run<Input, BaseContext = Context>(
-  operation: (input: TValueContext<BaseContext, Input>) => any
-): TOperator<BaseContext, Input, Input> {
+export function run<Input, TheApp extends BaseApp = App>(
+  operation: (input: TValueContext<TheApp, Input>) => any
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -675,9 +669,9 @@ export function run<Input, BaseContext = Context>(
   return instance
 }
 
-export function forEach<Input extends any[], BaseContext = Context>(
-  forEachItemOperator: TOperator<BaseContext, Input[0], any>
-): TOperator<BaseContext, Input, Input> {
+export function forEach<Input extends any[], TheApp extends BaseApp = App>(
+  forEachItemOperator: TOperator<TheApp, Input[0], any>
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -718,9 +712,9 @@ export function forEach<Input extends any[], BaseContext = Context>(
   return instance
 }
 
-export function parallel<Input, BaseContext = Context>(
-  operators: TOperator<BaseContext, Input, any>[]
-): TOperator<BaseContext, Input, Input> {
+export function parallel<Input, TheApp extends BaseApp = App>(
+  operators: TOperator<TheApp, Input, any>[]
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -760,9 +754,9 @@ export function parallel<Input, BaseContext = Context>(
   return instance
 }
 
-export function filter<Input, BaseContext = Context>(
-  operation: (input: TValueContext<BaseContext, Input>) => boolean
-): TOperator<BaseContext, Input, Input> {
+export function filter<Input, TheApp extends BaseApp = App>(
+  operation: (input: TValueContext<TheApp, Input>) => boolean
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next, final) => {
     if (err) next(err)
     else {
@@ -783,9 +777,9 @@ export function filter<Input, BaseContext = Context>(
   return instance
 }
 
-export function mutate<Input, BaseContext = Context>(
-  operation: (input: TValueContext<BaseContext, Input>) => void
-): Operator<Input, Input> {
+export function mutate<Input, TheApp extends BaseApp = App>(
+  operation: (input: TValueContext<TheApp, Input>) => void
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -809,12 +803,12 @@ export function mutate<Input, BaseContext = Context>(
 
 export function fork<
   Input,
-  Paths extends { [key: string]: Operator<Input, any> },
-  BaseContext = Context
+  Paths extends { [key: string]: TOperator<TheApp, Input, any> },
+  TheApp extends BaseApp = App
 >(
-  operation: (input: TValueContext<BaseContext, Input>) => keyof Paths,
+  operation: (input: TValueContext<TheApp, Input>) => keyof Paths,
   paths: Paths
-): TOperator<BaseContext, Input, Input> {
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -840,13 +834,13 @@ export function fork<
   return instance
 }
 
-export function when<Input, OutputA, OutputB, BaseContext = Context>(
-  operation: (input: TValueContext<BaseContext, Input>) => boolean,
+export function when<Input, OutputA, OutputB, TheApp extends BaseApp = App>(
+  operation: (input: TValueContext<TheApp, Input>) => boolean,
   paths: {
-    true: TOperator<BaseContext, Input, OutputA>
-    false: TOperator<BaseContext, Input, OutputB>
+    true: TOperator<TheApp, Input, OutputA>
+    false: TOperator<TheApp, Input, OutputB>
   }
-): TOperator<BaseContext, Input, OutputA | OutputB> {
+): TOperator<TheApp, Input, OutputA | OutputB> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -877,9 +871,9 @@ export function when<Input, OutputA, OutputB, BaseContext = Context>(
   return instance
 }
 
-export function wait<Input, BaseContext = Context>(
+export function wait<Input, TheApp extends BaseApp = App>(
   ms: number
-): TOperator<BaseContext, Input, Input> {
+): TOperator<TheApp, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -893,9 +887,9 @@ export function wait<Input, BaseContext = Context>(
   return instance
 }
 
-export function debounce<Input, BaseContext = Context>(
+export function debounce<Input, TheApp extends BaseApp = App>(
   ms: number
-): TOperator<BaseContext, Input, Input> {
+): TOperator<TheApp, Input, Input> {
   let timeout
   let previousFinal
   const instance = (err, context, next, final) => {

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -37,7 +37,11 @@ export type Action<Value = void> = TAction<App, Value>
 
 export type Context = TContext<App>
 
-export type Derive<Parent extends object, Value> = TDerive<App, Parent, Value>
+export type Derive<Parent extends object, Value> = TDerive<
+  App,
+  ResolveState<Parent>,
+  Value
+>
 
 export type Reaction = TReaction<App>
 
@@ -479,46 +483,46 @@ export class Overmind<Config extends Configuration> implements BaseApp {
   OPERATORS
   needs to be in this file for typing override to work
 */
-export type Operator<Input, Output> = TOperator<Input, Output, Context>
+export type Operator<Input, Output> = TOperator<Context, Input, Output>
 
 export function pipe<BaseContext, A, B, C>(
-  aOperator: TOperator<A, B, BaseContext>
-): TOperator<A, C, BaseContext>
+  aOperator: TOperator<BaseContext, A, B>
+): TOperator<BaseContext, A, C>
 
 export function pipe<BaseContext, A, B, C, D>(
-  aOperator: TOperator<A, B, BaseContext>,
-  bOperator: TOperator<B, C, BaseContext>
-): TOperator<A, D, BaseContext>
+  aOperator: TOperator<BaseContext, A, B>,
+  bOperator: TOperator<BaseContext, B, C>
+): TOperator<BaseContext, A, D>
 
 export function pipe<BaseContext, A, B, C, D, E>(
-  aOperator: TOperator<A, B, BaseContext>,
-  bOperator: TOperator<B, C, BaseContext>,
-  cOperator: TOperator<C, D, BaseContext>
-): TOperator<A, E, BaseContext>
+  aOperator: TOperator<BaseContext, A, B>,
+  bOperator: TOperator<BaseContext, B, C>,
+  cOperator: TOperator<BaseContext, C, D>
+): TOperator<BaseContext, A, E>
 
 export function pipe<BaseContext, A, B, C, D, E, F>(
-  aOperator: TOperator<A, B, BaseContext>,
-  bOperator: TOperator<B, C, BaseContext>,
-  cOperator: TOperator<C, D, BaseContext>,
-  dOperator: TOperator<D, E, BaseContext>
-): TOperator<A, F, BaseContext>
+  aOperator: TOperator<BaseContext, A, B>,
+  bOperator: TOperator<BaseContext, B, C>,
+  cOperator: TOperator<BaseContext, C, D>,
+  dOperator: TOperator<BaseContext, D, E>
+): TOperator<BaseContext, A, F>
 
 export function pipe<BaseContext, A, B, C, D, E, F, G>(
-  aOperator: TOperator<A, B, BaseContext>,
-  bOperator: TOperator<B, C, BaseContext>,
-  cOperator: TOperator<C, D, BaseContext>,
-  dOperator: TOperator<D, E, BaseContext>,
-  eOperator: TOperator<E, F, BaseContext>
-): TOperator<A, G, BaseContext>
+  aOperator: TOperator<BaseContext, A, B>,
+  bOperator: TOperator<BaseContext, B, C>,
+  cOperator: TOperator<BaseContext, C, D>,
+  dOperator: TOperator<BaseContext, D, E>,
+  eOperator: TOperator<BaseContext, E, F>
+): TOperator<BaseContext, A, G>
 
 export function pipe<BaseContext, A, B, C, D, E, F, G, H>(
-  aOperator: TOperator<A, B, BaseContext>,
-  bOperator: TOperator<B, C, BaseContext>,
-  cOperator: TOperator<C, D, BaseContext>,
-  dOperator: TOperator<D, E, BaseContext>,
-  eOperator: TOperator<E, F, BaseContext>,
-  fOperator: TOperator<F, G, BaseContext>
-): TOperator<A, H, BaseContext>
+  aOperator: TOperator<BaseContext, A, B>,
+  bOperator: TOperator<BaseContext, B, C>,
+  cOperator: TOperator<BaseContext, C, D>,
+  dOperator: TOperator<BaseContext, D, E>,
+  eOperator: TOperator<BaseContext, E, F>,
+  fOperator: TOperator<BaseContext, F, G>
+): TOperator<BaseContext, A, H>
 
 export function pipe(...operators) {
   const instance = (err, context, next, final = next) => {
@@ -632,7 +636,7 @@ function createNextPath(next) {
 
 export function map<Input, Output, BaseContext = Context>(
   operation: (input: TValueContext<BaseContext, Input>) => Output
-): TOperator<Input, Output extends Promise<infer U> ? U : Output, BaseContext> {
+): TOperator<BaseContext, Input, Output extends Promise<infer U> ? U : Output> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -650,7 +654,7 @@ export function map<Input, Output, BaseContext = Context>(
 
 export function run<Input, BaseContext = Context>(
   operation: (input: TValueContext<BaseContext, Input>) => any
-): TOperator<Input, Input, BaseContext> {
+): TOperator<BaseContext, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -672,8 +676,8 @@ export function run<Input, BaseContext = Context>(
 }
 
 export function forEach<Input extends any[], BaseContext = Context>(
-  forEachItemOperator: TOperator<Input[0], any, BaseContext>
-): TOperator<Input, Input, BaseContext> {
+  forEachItemOperator: TOperator<BaseContext, Input[0], any>
+): TOperator<BaseContext, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -715,8 +719,8 @@ export function forEach<Input extends any[], BaseContext = Context>(
 }
 
 export function parallel<Input, BaseContext = Context>(
-  operators: TOperator<Input, any, BaseContext>[]
-): TOperator<Input, Input, BaseContext> {
+  operators: TOperator<BaseContext, Input, any>[]
+): TOperator<BaseContext, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -758,7 +762,7 @@ export function parallel<Input, BaseContext = Context>(
 
 export function filter<Input, BaseContext = Context>(
   operation: (input: TValueContext<BaseContext, Input>) => boolean
-): TOperator<Input, Input, BaseContext> {
+): TOperator<BaseContext, Input, Input> {
   const instance = (err, context, next, final) => {
     if (err) next(err)
     else {
@@ -810,7 +814,7 @@ export function fork<
 >(
   operation: (input: TValueContext<BaseContext, Input>) => keyof Paths,
   paths: Paths
-): TOperator<Input, Input, BaseContext> {
+): TOperator<BaseContext, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -839,10 +843,10 @@ export function fork<
 export function when<Input, OutputA, OutputB, BaseContext = Context>(
   operation: (input: TValueContext<BaseContext, Input>) => boolean,
   paths: {
-    true: TOperator<Input, OutputA, BaseContext>
-    false: TOperator<Input, OutputB, BaseContext>
+    true: TOperator<BaseContext, Input, OutputA>
+    false: TOperator<BaseContext, Input, OutputB>
   }
-): TOperator<Input, OutputA | OutputB, BaseContext> {
+): TOperator<BaseContext, Input, OutputA | OutputB> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -875,7 +879,7 @@ export function when<Input, OutputA, OutputB, BaseContext = Context>(
 
 export function wait<Input, BaseContext = Context>(
   ms: number
-): TOperator<Input, Input, BaseContext> {
+): TOperator<BaseContext, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
     else {
@@ -891,7 +895,7 @@ export function wait<Input, BaseContext = Context>(
 
 export function debounce<Input, BaseContext = Context>(
   ms: number
-): TOperator<Input, Input, BaseContext> {
+): TOperator<BaseContext, Input, Input> {
   let timeout
   let previousFinal
   const instance = (err, context, next, final) => {

--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -1,5 +1,5 @@
 import { Mutation } from '../../proxy-state-tree'
-import { BaseApp, TAction, TDerive, TOperator } from './types'
+import { Configuration, TAction, TDerive, TOperator } from './types'
 
 export type SubType<Base, Condition> = Pick<
   Base,
@@ -110,8 +110,8 @@ export interface Events {
 
 // ============= PRIVATE TYPES FOR APP
 
-export type TBaseContext<App extends BaseApp> = App['effects'] & {
-  state: App['state']
+export type TBaseContext<Config extends Configuration> = Config['effects'] & {
+  state: ResolveState<Config['state'] & {}>
   execution: any
 }
 

--- a/packages/node_modules/overmind/src/reaction.test.ts
+++ b/packages/node_modules/overmind/src/reaction.test.ts
@@ -1,4 +1,4 @@
-import { Overmind, TAction, TApp, TReaction, run } from './'
+import { Overmind, TAction, TReaction, run } from './'
 
 describe('Reaction', () => {
   test('should instantiate app with reactions', () => {
@@ -17,15 +17,15 @@ describe('Reaction', () => {
         react,
       },
     }
-    type IApp = TApp<{
+    type IConfig = {
       state: {
         foo: string
       }
       actions: typeof config.actions
       reactions: typeof config.reactions
-    }>
-    type Action<Input = void> = TAction<IApp, Input>
-    type Reaction = TReaction<IApp>
+    }
+    type Action<Input = void> = TAction<IConfig, Input>
+    type Reaction = TReaction<IConfig>
     const app = new Overmind(config)
 
     app.actions.foo()
@@ -34,7 +34,7 @@ describe('Reaction', () => {
   test('should react to nested changes', () => {
     let hasRunReaction = false
     const foo: Action = ({ state }) => (state.foo[0].completed = true)
-    const hasRun = run<void, IApp>(() => {
+    const hasRun = run<void, IConfig>(() => {
       hasRunReaction = true
     })
     const react: Reaction = (reaction) => reaction((state) => state.foo, hasRun)
@@ -53,15 +53,15 @@ describe('Reaction', () => {
         react,
       },
     }
-    type IApp = TApp<{
+    type IConfig = {
       state: {
         foo: typeof config.state.foo
       }
       actions: typeof config.actions
       reactions: typeof config.reactions
-    }>
-    type Action<Input = void> = TAction<IApp, Input>
-    type Reaction = TReaction<IApp>
+    }
+    type Action<Input = void> = TAction<IConfig, Input>
+    type Reaction = TReaction<IConfig>
     const app = new Overmind(config)
     app.actions.foo()
     expect(hasRunReaction).toBe(true)

--- a/packages/node_modules/overmind/src/reaction.test.ts
+++ b/packages/node_modules/overmind/src/reaction.test.ts
@@ -1,4 +1,4 @@
-import { Overmind, TAction, TApp, TReaction, run, TContext } from './'
+import { Overmind, TAction, TApp, TReaction, run } from './'
 
 describe('Reaction', () => {
   test('should instantiate app with reactions', () => {
@@ -34,7 +34,7 @@ describe('Reaction', () => {
   test('should react to nested changes', () => {
     let hasRunReaction = false
     const foo: Action = ({ state }) => (state.foo[0].completed = true)
-    const hasRun = run<void, TContext<IApp>>(() => {
+    const hasRun = run<void, IApp>(() => {
       hasRunReaction = true
     })
     const react: Reaction = (reaction) => reaction((state) => state.foo, hasRun)

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -40,7 +40,7 @@ export type TAction<App extends BaseApp, Value> = (
   context: TValueContext<TContext<App>, Value>
 ) => any
 
-export type TOperator<Input, Output, OperatorContext extends TContext<any>> = (
+export type TOperator<OperatorContext extends TContext<any>, Input, Output> = (
   err: Error | null,
   val: TValueContext<OperatorContext, Input>,
   next: (
@@ -51,13 +51,13 @@ export type TOperator<Input, Output, OperatorContext extends TContext<any>> = (
 ) => void
 
 export type TDerive<App extends BaseApp, Parent extends object, Value> = (
-  parent: ResolveState<Parent>,
+  parent: Parent,
   state: App['state']
 ) => Value
 
 export type TReaction<App extends BaseApp> = (
   reaction: (
     getState: (state: App['state']) => any,
-    action: TAction<App, void> | TOperator<void, any, TContext<App>>
+    action: TAction<App, void> | TOperator<TContext<App>, void, any>
   ) => any
 ) => any

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -1,5 +1,4 @@
 import { ResolveActions, ResolveState, TBaseContext } from './internalTypes'
-import { Operator } from './'
 
 /** ===== PUBLIC API
  */
@@ -27,27 +26,19 @@ export interface TApp<Config extends Configuration> {
   effects: Config['effects'] & {}
 }
 
-export type TContext<App extends BaseApp> = TBaseContext<App>
-
-export type TValueContext<
-  BaseContext extends TContext<any>,
-  Value
-> = BaseContext & {
+export type TValueContext<App extends BaseApp, Value> = TBaseContext<App> & {
   value: Value
 }
 
 export type TAction<App extends BaseApp, Value> = (
-  context: TValueContext<TContext<App>, Value>
+  context: TValueContext<App, Value>
 ) => any
 
-export type TOperator<OperatorContext extends TContext<any>, Input, Output> = (
+export type TOperator<App extends BaseApp, Input, Output> = (
   err: Error | null,
-  val: TValueContext<OperatorContext, Input>,
-  next: (
-    err: Error | null,
-    val?: TValueContext<OperatorContext, Output>
-  ) => void,
-  final?: (err, Error, val?: TValueContext<OperatorContext, Output>) => void
+  val: TValueContext<App, Input>,
+  next: (err: Error | null, val?: TValueContext<App, Output>) => void,
+  final?: (err, Error, val?: TValueContext<App, Output>) => void
 ) => void
 
 export type TDerive<App extends BaseApp, Parent extends object, Value> = (
@@ -58,6 +49,6 @@ export type TDerive<App extends BaseApp, Parent extends object, Value> = (
 export type TReaction<App extends BaseApp> = (
   reaction: (
     getState: (state: App['state']) => any,
-    action: TAction<App, void> | TOperator<TContext<App>, void, any>
+    action: TAction<App, void> | TOperator<App, void, any>
   ) => any
 ) => any

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -18,37 +18,41 @@ export type BaseApp = {
   actions: {}
 }
 
-export interface TApp<Config extends Configuration> {
-  // Resolves `Derive` types in state.
-  state: ResolveState<Config['state'] & {}>
-  // Transform actions into callable functions.
-  actions: ResolveActions<Config['actions']>
+export interface TConfig<Config extends Configuration> {
+  state: Config['state'] & {}
+  actions: Config['actions']
   effects: Config['effects'] & {}
 }
 
-export type TValueContext<App extends BaseApp, Value> = TBaseContext<App> & {
+export type TValueContext<Config extends Configuration, Value> = TBaseContext<
+  Config
+> & {
   value: Value
 }
 
-export type TAction<App extends BaseApp, Value> = (
-  context: TValueContext<App, Value>
+export type TAction<Config extends Configuration, Value> = (
+  context: TValueContext<Config, Value>
 ) => any
 
-export type TOperator<App extends BaseApp, Input, Output> = (
+export type TOperator<Config extends Configuration, Input, Output> = (
   err: Error | null,
-  val: TValueContext<App, Input>,
-  next: (err: Error | null, val?: TValueContext<App, Output>) => void,
-  final?: (err, Error, val?: TValueContext<App, Output>) => void
+  val: TValueContext<Config, Input>,
+  next: (err: Error | null, val?: TValueContext<Config, Output>) => void,
+  final?: (err, Error, val?: TValueContext<Config, Output>) => void
 ) => void
 
-export type TDerive<App extends BaseApp, Parent extends object, Value> = (
-  parent: Parent,
-  state: App['state']
+export type TDerive<
+  Config extends Configuration,
+  Parent extends object,
+  Value
+> = (
+  parent: ResolveState<Parent>,
+  state: ResolveState<Config['state'] & {}>
 ) => Value
 
-export type TReaction<App extends BaseApp> = (
+export type TReaction<Config extends Configuration> = (
   reaction: (
-    getState: (state: App['state']) => any,
-    action: TAction<App, void> | TOperator<App, void, any>
+    getState: (state: ResolveState<Config['state'] & {}>) => any,
+    action: TAction<Config, void> | TOperator<Config, void, any>
   ) => any
 ) => any


### PR DESCRIPTION
- [x] first argument of TOperator is Context (same convention as other T... things)
- [x] TDerive takes resolved parent (Parent has same nature as App)