### PR TITLE
fix(overmind): use the full and complete app for onInitialize

### DIFF
--- a/packages/node_modules/overmind-devtools/src/app/actions.ts
+++ b/packages/node_modules/overmind-devtools/src/app/actions.ts
@@ -31,7 +31,7 @@ import {
 } from './operators'
 
 export const onInitialize: OnInitialize = async ({
-  value: actions,
+  value: app,
   state,
   storage,
   connector,
@@ -40,7 +40,7 @@ export const onInitialize: OnInitialize = async ({
   if (port) {
     state.port = port
   }
-  connector.onMessage(actions.onMessage)
+  connector.onMessage(app.actions.onMessage)
   connector.connect(state.port)
 }
 

--- a/packages/node_modules/overmind-devtools/src/app/effects.ts
+++ b/packages/node_modules/overmind-devtools/src/app/effects.ts
@@ -1,5 +1,5 @@
 import * as jsonStorage from 'electron-json-storage'
-import BackendConnector from 'overmind-devtools/src/BackendConnector'
+import BackendConnector from '../BackendConnector'
 
 export const connector = new BackendConnector()
 
@@ -31,9 +31,9 @@ export const storage = {
             // Insanely weird that when "no value", an empty
             // object is returned. Should be null
             typeof data === 'object' &&
-            !Array.isArray(data) &&
-            data !== null &&
-            Object.keys(data).length === 0
+              !Array.isArray(data) &&
+              data !== null &&
+              Object.keys(data).length === 0
               ? null
               : data
           )

--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -81,12 +81,13 @@ describe('Overmind', () => {
     expect(app.state.foo).toEqual('bar')
   })
 
-  test('should instantiate app with onInitialize', () => {
+  test('should instantiate app with onInitialize', async () => {
     expect.assertions(2)
+    let value: any
     const app = new Overmind({
       onInitialize(context) {
         expect(context.state.foo).toBe('bar')
-        expect(typeof context.value.doThis === 'function').toBe(true)
+        value = context.value
       },
       state: {
         foo: 'bar',
@@ -95,8 +96,8 @@ describe('Overmind', () => {
         doThis() {},
       },
     })
-
-    return app.initialized
+    await app.initialized
+    expect(value).toBe(app)
   })
   test('should be able to type actions', () => {
     expect.assertions(2)

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -151,7 +151,7 @@ export class Overmind<Config extends Configuration> implements Configuration {
         configuration.onInitialize
       )
 
-      this.initialized = Promise.resolve(onInitialize(this.actions))
+      this.initialized = Promise.resolve(onInitialize(this))
     } else {
       this.initialized = Promise.resolve(null)
     }

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -1,4 +1,5 @@
 import { ResolveActions, ResolveState, TBaseContext } from './internalTypes'
+import { Overmind } from './'
 
 /** ===== PUBLIC API
  */
@@ -58,5 +59,5 @@ export type TReaction<Config extends Configuration> = (
 ) => any
 
 export type TOnInitialize<Config extends Configuration> = (
-  context: TValueContext<Config, ResolveActions<Config['actions']>>
+  context: TValueContext<Config, Overmind<Config>>
 ) => void


### PR DESCRIPTION
This is the only way for advance uses of this important initialization step, like connecting components in configurations.

It's really the only moment in the whole app lifetime that the modules get to have access to the app itself and there really are some legitimate and important use cases. Just passing the actions does not cut it.