### PR TITLE
fix(overmind): fix ResolveState to avoid circular definition of TDerive

### DIFF
--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -115,8 +115,10 @@ export type TBaseContext<Config extends Configuration> = Config['effects'] & {
   execution: any
 }
 
+type Derived = (parent: any, config: any) => any
+
 export type ResolveState<State extends object> = {
-  [P in keyof State]: State[P] extends TDerive<any, any, any>
+  [P in keyof State]: State[P] extends Derived
     ? ReturnType<State[P]>
     : State[P] extends Array<any>
     ? State[P]


### PR DESCRIPTION
Without this fix, `ResolveState` never resolves the TDerive types because of a circular definition 

TDerive uses ResolveState which uses TDerive