### PR TITLE
fix(overmind): add TApp type back

### DIFF
--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -25,6 +25,19 @@ export interface TConfig<Config extends Configuration> {
   effects: Config['effects'] & {}
 }
 
+// This is the type of the `app` argument passed in components.
+export type TApp<Config extends Configuration> = {
+  // Resolves `Derive` types in state.
+  state: ResolveState<Config['state'] & {}>
+  actions: ResolveActions<Config['actions']>
+  reaction: (
+    name: string,
+    stateCb: (state: TApp<Config>['state']) => any,
+    Function
+  ) => void
+}
+
+// This is the type of the argument passed in actions.
 export type TValueContext<Config extends Configuration, Value> = TBaseContext<
   Config
 > & {


### PR DESCRIPTION
It is useful to type helper functions in actions and components.