### PR TITLE
fix(overmind-react): refactor createHook with component lifecycle fixes

### DIFF
--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -50,11 +50,34 @@ export const createHook = <A extends Overmind<Configuration>>(overmind: A) => {
       typeof component.__componentId === 'undefined'
         ? nextComponentId++
         : component.__componentId
-    const [overmindState, setOvermindState] = useState(null)
     const trackId = overmind.trackState()
+    const [overmindState, setOvermindState] = useState(() => {
+      const paths = overmind.clearTrackState(trackId)
+      componentInstanceId++
+      overmind.eventHub.emitAsync(EventType.COMPONENT_ADD, {
+        componentId: component.__componentId,
+        componentInstanceId,
+        name,
+        paths: Array.from(paths),
+      })
+      return {
+        componentInstanceId,
+        listener: overmind.addFlushListener(paths, (flushId) => {
+          overmind.eventHub.emitAsync(EventType.COMPONENT_UPDATE, {
+            componentId: component.__componentId,
+            componentInstanceId,
+            name,
+            flushId,
+            paths: Array.from(paths),
+          })
+          setOvermindState((state) => state)
+        }),
+      }
+    })
+
     useEffect(() => {
       const paths = overmind.clearTrackState(trackId)
-      if (overmindState) {
+      if (paths) {
         overmind.eventHub.emitAsync(EventType.COMPONENT_UPDATE, {
           componentId: component.__componentId,
           componentInstanceId: overmindState.componentInstanceId,
@@ -62,44 +85,19 @@ export const createHook = <A extends Overmind<Configuration>>(overmind: A) => {
           paths: Array.from(paths),
         })
         overmindState.listener.update(paths)
-      } else {
-        const thisComponentInstanceId = componentInstanceId++
-        setOvermindState({
-          componentInstanceId: thisComponentInstanceId,
-          listener: overmind.addFlushListener(paths, (flushId) => {
-            overmind.eventHub.emitAsync(EventType.COMPONENT_UPDATE, {
-              componentId: component.__componentId,
-              componentInstanceId: thisComponentInstanceId,
-              name,
-              flushId,
-              paths: Array.from(paths),
-            })
-            setOvermindState((state) => state)
-          }),
-        })
-        overmind.eventHub.emitAsync(EventType.COMPONENT_ADD, {
-          componentId: component.__componentId,
-          componentInstanceId: thisComponentInstanceId,
-          name,
-          paths: Array.from(paths),
-        })
       }
     })
-    useEffect(
-      () => {
-        return () => {
-          if (overmindState) {
-            overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
-              componentId: component.__componentId,
-              componentInstanceId: overmindState.componentInstanceId,
-              name,
-            })
-            overmindState.listener.dispose()
-          }
-        }
-      },
-      [component.__componentId]
-    )
+    useEffect(() => {
+      return () => {
+        overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
+          componentId: component.__componentId,
+          componentInstanceId: overmindState.componentInstanceId,
+          name,
+        })
+        overmindState.listener.dispose()
+      }
+    }, [])
+
     return overmind
   }
 }

--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -74,7 +74,7 @@ export const createHook = <A extends Overmind<Configuration>>(overmind: A) => {
     useEffect(() => {
       const paths = overmind.clearTrackState(trackId)
 
-      if (paths) {
+      if (paths && paths.size) {
         const listener = overmind.addFlushListener(paths, (flushId) => {
           forceUpdate(flushId)
           overmind.eventHub.emitAsync(EventType.COMPONENT_UPDATE, {

--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -88,12 +88,14 @@ export const createHook = <A extends Overmind<Configuration>>(overmind: A) => {
     useEffect(
       () => {
         return () => {
-          overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
-            componentId: component.__componentId,
-            componentInstanceId: overmindState.componentInstanceId,
-            name,
-          })
-          overmindState.listener.dispose()
+          if (overmindState) {
+            overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
+              componentId: component.__componentId,
+              componentInstanceId: overmindState.componentInstanceId,
+              name,
+            })
+            overmindState.listener.dispose()
+          }
         }
       },
       [component.__componentId]

--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -50,53 +50,46 @@ export const createHook = <A extends Overmind<Configuration>>(overmind: A) => {
       typeof component.__componentId === 'undefined'
         ? nextComponentId++
         : component.__componentId
-    const trackId = overmind.trackState()
-    const [overmindState, setOvermindState] = useState(() => {
-      const paths = overmind.clearTrackState(trackId)
-      componentInstanceId++
+    const [thisComponentInstanceId] = useState(() => componentInstanceId++)
+    const [_, forceUpdate] = useState(null)
+
+    useEffect(() => {
       overmind.eventHub.emitAsync(EventType.COMPONENT_ADD, {
         componentId: component.__componentId,
-        componentInstanceId,
+        componentInstanceId: thisComponentInstanceId,
         name,
-        paths: Array.from(paths),
+        paths: [],
       })
-      return {
-        componentInstanceId,
-        listener: overmind.addFlushListener(paths, (flushId) => {
+      return () => {
+        overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
+          componentId: component.__componentId,
+          componentInstanceId: thisComponentInstanceId,
+          name,
+        })
+      }
+    }, [])
+
+    const trackId = overmind.trackState()
+
+    useEffect(() => {
+      const paths = overmind.clearTrackState(trackId)
+
+      if (paths) {
+        const listener = overmind.addFlushListener(paths, (flushId) => {
+          forceUpdate(flushId)
           overmind.eventHub.emitAsync(EventType.COMPONENT_UPDATE, {
             componentId: component.__componentId,
-            componentInstanceId,
+            componentInstanceId: thisComponentInstanceId,
             name,
             flushId,
             paths: Array.from(paths),
           })
-          setOvermindState((state) => state)
-        }),
+        })
+        return () => {
+          listener.dispose()
+        }
       }
     })
-
-    useEffect(() => {
-      const paths = overmind.clearTrackState(trackId)
-      if (paths) {
-        overmind.eventHub.emitAsync(EventType.COMPONENT_UPDATE, {
-          componentId: component.__componentId,
-          componentInstanceId: overmindState.componentInstanceId,
-          name,
-          paths: Array.from(paths),
-        })
-        overmindState.listener.update(paths)
-      }
-    })
-    useEffect(() => {
-      return () => {
-        overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
-          componentId: component.__componentId,
-          componentInstanceId: overmindState.componentInstanceId,
-          name,
-        })
-        overmindState.listener.dispose()
-      }
-    }, [])
 
     return overmind
   }


### PR DESCRIPTION
Create hook was setting the initial state to null and then updating with an effect. This caused a number of issues.

1. The tidy up effect would never work due to being created in the first render and not being updated (closure bug).
2. Every computed using the overmind would always render twice.
3. Due to 1. react would complain of memory leaks.
4. Any components using overmind state to configure internal useState (eg with forms) would get an initial value of null and then never update (due to the way that useState works.