### PR TITLE
false devtools shouldn't try to initializeDevtools

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -105,12 +105,8 @@ export class Overmind<Config extends Configuration> implements Configuration {
       The action factory function
     */
 
-    if (
-      !IS_PRODUCTION &&
-      options.devtools !== false &&
-      typeof window !== 'undefined'
-    ) {
-      if (location.hostname === 'localhost' || options.devtools) {
+    if (!IS_PRODUCTION && typeof window !== 'undefined') {
+      if (options.devtools || (location.hostname === 'localhost' && options.devtools !== false)) {
         this.initializeDevtools(options.devtools, eventHub, proxyStateTree)
       } else {
         console.warn(


### PR DESCRIPTION
## What happened
My localhost app kept trying to connect to the  devtools even when options.devtools were set in false.

## What do I expect with this change

* I expect that when devtools is false we don't try to initialize the debugger.
* No options default to empty object, this will still try to connect to the default devTools in localhost unless options.devtools is a false boolean

### Comments
Seems to be a simple boolean operator typo.
