### PR TITLE
use `options.name` as name if provided

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -193,11 +193,14 @@ export class Overmind<Config extends Configuration> implements Configuration {
           location.hostname === 'localhost' &&
           options.devtools !== false)
       ) {
-        this.initializeDevtools(
-          options.devtools === true ? 'localhost:3031' : options.devtools,
-          eventHub,
-          proxyStateTree
-        )
+        const host =
+          options.devtools === true ? 'localhost:3031' : options.devtools
+        const name =
+          options.name || typeof document === 'undefined'
+            ? 'NoName'
+            : document.title || 'NoName'
+
+        this.initializeDevtools(host, name, eventHub, proxyStateTree)
       } else {
         warning +=
           '\n\n - You are not running on localhost. You will have to manually define the devtools option to connect'
@@ -500,10 +503,8 @@ export class Overmind<Config extends Configuration> implements Configuration {
       return result
     })
   }
-  private initializeDevtools(host, eventHub, proxyStateTree) {
-    const devtools = new Devtools(
-      typeof document === 'undefined' ? 'NoName' : document.title || 'NoName'
-    )
+  private initializeDevtools(host, name, eventHub, proxyStateTree) {
+    const devtools = new Devtools(name)
     devtools.connect(
       host,
       (message: Message) => {


### PR DESCRIPTION
I extracted all the resolution logic for `host` and `name` from `initializeDevtools` to have them in one place. 