### PR TITLE
fix(proxy-state-tree): fix function to avoid breaking types being exported

### DIFF
--- a/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
+++ b/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
@@ -93,7 +93,9 @@ export class Proxifier {
   shouldTrackMutations(path) {
     return (
       this.tree.master.options.devmode ||
-      (path && this.tree.master.pathDependencies[path])
+      // We need the !! to avoid weird types for shouldTrackMutations that
+      // actually break (because they contain references to 'src')
+      !!(path && this.tree.master.pathDependencies[path])
     )
   }
 


### PR DESCRIPTION
This avoids the following error:

```
../../../../node_modules/proxy-state-tree/lib/Proxyfier.d.ts(14,56): error TS2307: Cannot find module 'proxy-state-tree/src/types'.
```