### PR TITLE
fix(overmind): fix TStateObject types so that resolve works 

### DIFF
--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -27,6 +27,8 @@ export type TStateObject =
         | number
         | boolean
         | object
+        | null
+        | undefined
     }
   | undefined
 


### PR DESCRIPTION
If the Config has `null` or `undefined` as possible values for keys, the object is not seen as a TStateObject and prevents derived from being resolved in this object.

This allows `null` and `undefined` values.