### PR TITLE
wrap showUsersPage() in action() so it works w/ parallel()

### DIFF
--- a/packages/overmind-website/examples/guide/routing/tab.ts
+++ b/packages/overmind-website/examples/guide/routing/tab.ts
@@ -52,14 +52,14 @@ export const showHomePage = ({ state }) => {
   state.currentPage = 'home'
 }
 
-export const showUsersPage = async ({ value: params, state, effects }) => {
+export const showUsersPage = action( async ({ value: params, state, effects }) => {
   if (!params.id) state.modalUser = null
 
   state.currentPage = 'users'
   state.isLoadingUsers = true
   state.users = await effects.api.getUsers()
   state.isLoadingUsers = false
-}
+})
 
 export const showUserModal = parallel(
     showUsersPage,


### PR DESCRIPTION
showUsersPage() is part of a `parallel()` operator pipeline so needs to be wrapped in an `action()` operator

incidentally I created a codesandbox demo of for the routing tutorial.

here is the bug in action: https://codesandbox.io/s/mzmq42wjq9

here is the fix: https://codesandbox.io/s/github/100ideas/overmind-routing-demo/tree/codesandbox_v1