### PR TITLE
fix(overmind): use a temporary action context

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -1,35 +1,35 @@
 import { EventEmitter } from 'betsy'
 import isPlainObject from 'is-plain-obj'
 import {
+  IFlushCallback,
+  IMutation,
+  IMutationCallback,
   IS_PROXY,
   ProxyStateTree,
   TTree,
-  IMutation,
   VALUE,
-  IMutationCallback,
-  IFlushCallback,
 } from 'proxy-state-tree'
 import { Derived } from './derived'
 import { Devtools, Message, safeValue, safeValues } from './Devtools'
 import {
   Events,
   EventType,
+  Execution,
+  NestedPartial,
   Options,
   ResolveActions,
-  ResolveState,
-  Execution,
   ResolveMockActions,
-  NestedPartial,
+  ResolveState,
 } from './internalTypes'
 import { proxifyEffects } from './proxyfyEffects'
 import {
-  IConfiguration,
+  AContext,
   IAction,
+  IConfiguration,
   IDerive,
   IOperator,
-  IContext,
-  TOnInitialize,
   IState,
+  TOnInitialize,
 } from './types'
 
 export * from './types'
@@ -843,7 +843,7 @@ function createNextPath(next) {
 }
 
 export function map<Input, Output, ThisConfig extends IConfiguration = Config>(
-  operation: (context: IContext<ThisConfig, Input>, value: Input) => Output
+  operation: (context: AContext<ThisConfig, Input>, value: Input) => Output
 ): IOperator<ThisConfig, Input, Output extends Promise<infer U> ? U : Output> {
   const instance = (err, context, next) => {
     if (err) next(err)
@@ -961,7 +961,7 @@ export function parallel<Input, ThisConfig extends IConfiguration = Config>(
 }
 
 export function filter<Input, ThisConfig extends IConfiguration = Config>(
-  operation: (context: IContext<ThisConfig, Input>, value: Input) => boolean
+  operation: (context: AContext<ThisConfig, Input>, value: Input) => boolean
 ): IOperator<ThisConfig, Input, Input> {
   const instance = (err, context, next, final) => {
     if (err) next(err)
@@ -995,7 +995,7 @@ export function filter<Input, ThisConfig extends IConfiguration = Config>(
 }
 
 export function action<Input, ThisConfig extends IConfiguration = Config>(
-  operation: (context: IContext<ThisConfig, Input>, value: Input) => void
+  operation: (context: AContext<ThisConfig, Input>, value: Input) => void
 ): IOperator<ThisConfig, Input, Input> {
   const instance = (err, context, next) => {
     if (err) next(err)
@@ -1066,7 +1066,7 @@ export function fork<
   ThisConfig extends IConfiguration = Config
 >(
   operation: (
-    context: IContext<ThisConfig, Input>,
+    context: AContext<ThisConfig, Input>,
     value: Input
   ) => keyof Paths,
   paths: Paths
@@ -1103,7 +1103,7 @@ export function when<
   OutputB,
   ThisConfig extends IConfiguration = Config
 >(
-  operation: (context: IContext<ThisConfig, Input>, value: Input) => boolean,
+  operation: (context: AContext<ThisConfig, Input>, value: Input) => boolean,
   paths: {
     true: IOperator<ThisConfig, Input, OutputA>
     false: IOperator<ThisConfig, Input, OutputB>

--- a/packages/node_modules/overmind/src/types.ts
+++ b/packages/node_modules/overmind/src/types.ts
@@ -32,16 +32,19 @@ export interface IConfig<ThisConfig extends IConfiguration> {
   effects: ThisConfig['effects'] & {}
 }
 
-// DEPRECATED: Value is to be removed
-export type IContext<ThisConfig extends IConfiguration, Value> = {
+export type IContext<ThisConfig extends IConfiguration> = {
   state: ResolveState<ThisConfig['state']>
   actions: ResolveActions<ThisConfig['actions']>
   effects: ThisConfig['effects']
-  value: Value
 }
 
+// DEPRECATED: Value is to be removed
+export type AContext<ThisConfig extends IConfiguration, Value> = IContext<
+  ThisConfig
+> & { value: Value }
+
 export interface IAction<ThisConfig extends IConfiguration, Value> {
-  (context: IContext<ThisConfig, Value>, value: Value): any
+  (context: AContext<ThisConfig, Value>, value: Value): any
 }
 
 // We do not type operators as their low level implementation, but rather
@@ -50,7 +53,7 @@ export type IOperator<
   ThisConfig extends IConfiguration,
   Input,
   Output = Input
-> = (context: IContext<ThisConfig, Input>, value: Input) => Output
+> = (context: AContext<ThisConfig, Input>, value: Input) => Output
 
 export type IDerive<
   ThisConfig extends IConfiguration,
@@ -63,7 +66,7 @@ export type IDerive<
 
 export interface TOnInitialize<ThisConfig extends IConfiguration> {
   (
-    context: IContext<ThisConfig, Overmind<ThisConfig>>,
+    context: AContext<ThisConfig, Overmind<ThisConfig>>,
     value: Overmind<ThisConfig>
   ): void
 }


### PR DESCRIPTION
 to make IContext compatible with react hooks and component types.

```ts
const ctx = useOvermind()

function foo(ctx: IContext<Config, undefined>) {} // Here `value` is expected but

foo(ctx) // Not compatible: Property 'value' is missing in type...
```

