### PR TITLE
Update options.name docs

### DIFF
--- a/packages/overmind-website/api/overmind.md
+++ b/packages/overmind-website/api/overmind.md
@@ -32,7 +32,7 @@ h(Example, { name: "api/app_options_logproxies" })
 ```
 
 ## options.name
-If you have multiple instances of Overmind on the same page you can name your app to differentiate it in the devtools.
+If you have multiple instances of Overmind on the same page you can name your app to differentiate them.
 
 ```marksy
 h(Example, { name: "api/app_options_name" })


### PR DESCRIPTION
As far as I understand config.name is not only for better developer tools support but also to differentiate the state and actions for overmind. 

Here you can see what I mean:
https://codesandbox.io/s/kxykm17pz5