### PR TITLE
Small changes in overmind api docs

### DIFF
--- a/packages/overmind-website/api/overmind.md
+++ b/packages/overmind-website/api/overmind.md
@@ -10,7 +10,7 @@ You can pass a second argument to the **Overmind** constructor. This is an optio
 
 ## addMutationListener
 
-It is possible to listen to all mutations performed in Overmind. This allows you to create special effects based on mutations within a certain domain of your app, or whatever else you come up with. Note that this method triggers instantly when the mutation occurs, you might rather want to use **addFlushListener** to be notified about batched changes, like the components does.
+It is possible to listen to all mutations performed in Overmind. This allows you to create special effects based on mutations within a certain domain of your app, or whatever else you come up with. Note that this method triggers before the mutation occurs, you might rather want to use **addFlushListener** to be notified about batched changes, like the components does.
 
 ```marksy
 h(Example, { name: "api/app_addMutationListener" })
@@ -18,7 +18,7 @@ h(Example, { name: "api/app_addMutationListener" })
 
 ## addFlushListener
 
-The **addMutationListener** triggers whenever there is a mutation. The **addFLushListener** triggers whenever Overmind tells components to render again. It can have multiple mutations related to it.
+The **addMutationListener** triggers whenever there is a mutation. The **addFlushListener** triggers whenever Overmind tells components to render again. It can have multiple mutations related to it.
 
 ```marksy
 h(Example, { name: "api/app_addFlushListener" })


### PR DESCRIPTION
One change is a typo and the other tries to be more direct in telling that Add Mutation Listener executes the function before the mutation is executed. 