### PR TITLE
Fix deepCopy to pass getters to cloned object

### DIFF
--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import { EventType, Overmind, IAction } from './'
+import { EventType, Overmind, IAction, createOvermindMock } from './'
 import { namespaced } from './config'
 
 function toJSON(obj) {
@@ -330,5 +330,25 @@ describe('Overmind', () => {
       })
     ).not.toThrow()
     expect(app.state.item.isAwesome).toBe(false)
+  })
+})
+
+describe('Overmind mock', () => {
+  test('should preserve getters', async (done) => {
+    expect.assertions(1)
+    const state = {
+      value: 0,
+      get valuePlusTwo() { return this.value + 2 }
+    }
+    const updateValue: Action = (context) => context.state.value = 15
+    const actions = { updateValue }
+    const config = { state, actions}
+    type Config = typeof config
+    interface Action<Value = void> extends IAction<Config, Value> {}
+
+    const mock = createOvermindMock(config)
+    await mock.actions.updateValue()
+    expect(mock.state.valuePlusTwo).toEqual(17)
+    done()
   })
 })

--- a/packages/node_modules/overmind/src/utils.test.ts
+++ b/packages/node_modules/overmind/src/utils.test.ts
@@ -1,0 +1,14 @@
+import { deepCopy } from './utils'
+
+describe('deepCopy', () => {
+  test('should be able to preserve getters', () => {
+    expect.assertions(1)
+    const original = {
+        value: 0,
+        get valuePlusTwo() { return this.value + 2 }
+    }
+    const copy = deepCopy(original)
+    copy.value = 15
+    expect(copy.valuePlusTwo).toBe(17)
+  })
+})

--- a/packages/node_modules/overmind/src/utils.ts
+++ b/packages/node_modules/overmind/src/utils.ts
@@ -29,9 +29,11 @@ export const makeStringifySafeMutations = (mutations: IMutation[]) => {
 
 export function deepCopy(obj) {
   if (isPlainObject(obj)) {
-    return Object.keys(obj).reduce((aggr, key) => {
-      aggr[key] = deepCopy(obj[key])
-
+    return Object.keys(obj).reduce((aggr: any, key) => {
+      if(obj.__lookupGetter__(key))
+        aggr.__defineGetter__(key, obj.__lookupGetter__(key))
+      else 
+        aggr[key] = deepCopy(obj[key])
       return aggr
     }, {})
   } else if (Array.isArray(obj)) {

--- a/packages/node_modules/overmind/src/utils.ts
+++ b/packages/node_modules/overmind/src/utils.ts
@@ -30,10 +30,16 @@ export const makeStringifySafeMutations = (mutations: IMutation[]) => {
 export function deepCopy(obj) {
   if (isPlainObject(obj)) {
     return Object.keys(obj).reduce((aggr: any, key) => {
-      if(obj.__lookupGetter__(key))
-        aggr.__defineGetter__(key, obj.__lookupGetter__(key))
-      else 
-        aggr[key] = deepCopy(obj[key])
+      const originalDescriptor = Object.getOwnPropertyDescriptor(obj, key)
+      const isAGetter = originalDescriptor && 'get' in originalDescriptor
+      const value = obj[key]
+
+      if (isPlainObject(value) && !isAGetter) {
+        aggr[key] = deepCopy(value)
+      } else {
+        Object.defineProperty(aggr, key, originalDescriptor as any)
+      }
+
       return aggr
     }, {})
   } else if (Array.isArray(obj)) {

--- a/packages/node_modules/overmind/src/utils.ts
+++ b/packages/node_modules/overmind/src/utils.ts
@@ -30,6 +30,10 @@ export const makeStringifySafeMutations = (mutations: IMutation[]) => {
 export function deepCopy(obj) {
   if (isPlainObject(obj)) {
     return Object.keys(obj).reduce((aggr: any, key) => {
+      if (key === '__esModule') {
+        return aggr
+      }
+
       const originalDescriptor = Object.getOwnPropertyDescriptor(obj, key)
       const isAGetter = originalDescriptor && 'get' in originalDescriptor
       const value = obj[key]


### PR DESCRIPTION
The previous implementation would take `{ get x() { return 123 } }` and return `{ x: 123 }` which resulted in problems when I was trying to run tests with createOvermindMock because all calculations based on this, were no longer recalculated