### PR TITLE
Fix incorrect export name

### DIFF
--- a/packages/overmind-website/examples/guide/runningsideeffects/object.ts
+++ b/packages/overmind-website/examples/guide/runningsideeffects/object.ts
@@ -23,7 +23,7 @@ export const api = {
           code: `
 import axios from 'axios'
 
-export const http = {
+export const api = {
   async getCurrentUser() {
     const response = await axios.get('/user')
 


### PR DESCRIPTION
The name of this export should be `api` (as it is with the TypeScript example).