### PR TITLE
FIX Throw error during merge if encounter duplicate keys

### DIFF
--- a/packages/node_modules/overmind/src/config/index.ts
+++ b/packages/node_modules/overmind/src/config/index.ts
@@ -110,8 +110,20 @@ export function merge(...configurations: IConfiguration[]): IConfiguration {
     [] as any[]
   )
 
-  return configurations.reduce(
+  const reducedConfigurations = configurations.reduce(
     (aggr, config) => {
+      let stateDuplicates = aggr.state ? Object.keys(aggr.state).some( key => config.state ? Object.keys(config.state).includes(key) : false) : false;
+      let actionsDuplicates = aggr.actions ? Object.keys(aggr.actions).some( key => config.actions ? Object.keys(config.actions).includes(key) : false) : false;
+      let effectsDuplicates = aggr.effects ? Object.keys(aggr.effects).some( key => config.effects ? Object.keys(config.effects).includes(key) : false) : false;
+      if (stateDuplicates){
+        throw "OVERMIND ERRROR: At least one state definition contains a duplicate key"
+      }
+      if (actionsDuplicates) {
+        throw "OVERMIND ERRROR: At least one actions definition contains a duplicate key"
+      }
+      if (effectsDuplicates) {
+        throw "OVERMIND ERRROR: At least one effects definition contains a duplicate key"
+      }
       return {
         onInitialize: aggr.onInitialize,
         state: {
@@ -138,6 +150,7 @@ export function merge(...configurations: IConfiguration[]): IConfiguration {
       actions: {},
     }
   )
+  return reducedConfigurations
 }
 
 /*

--- a/packages/node_modules/overmind/src/config/index.ts
+++ b/packages/node_modules/overmind/src/config/index.ts
@@ -112,17 +112,17 @@ export function merge(...configurations: IConfiguration[]): IConfiguration {
 
   const reducedConfigurations = configurations.reduce(
     (aggr, config) => {
-      let stateDuplicates = aggr.state ? Object.keys(aggr.state).some( key => config.state ? Object.keys(config.state).includes(key) : false) : false;
-      let actionsDuplicates = aggr.actions ? Object.keys(aggr.actions).some( key => config.actions ? Object.keys(config.actions).includes(key) : false) : false;
-      let effectsDuplicates = aggr.effects ? Object.keys(aggr.effects).some( key => config.effects ? Object.keys(config.effects).includes(key) : false) : false;
+      const stateDuplicates = aggr.state ? Object.keys(aggr.state).some( key => config.state ? Object.keys(config.state).includes(key) : false) : false;
+      const actionsDuplicates = aggr.actions ? Object.keys(aggr.actions).some( key => config.actions ? Object.keys(config.actions).includes(key) : false) : false;
+      const effectsDuplicates = aggr.effects ? Object.keys(aggr.effects).some( key => config.effects ? Object.keys(config.effects).includes(key) : false) : false;
       if (stateDuplicates){
-        throw "OVERMIND ERRROR: At least one state definition contains a duplicate key"
+        throw new Error("Merge conflict: at least one state definition contains a duplicate key")
       }
       if (actionsDuplicates) {
-        throw "OVERMIND ERRROR: At least one actions definition contains a duplicate key"
+        throw new Error("Merge conflict: at least one actions definition contains a duplicate key")
       }
       if (effectsDuplicates) {
-        throw "OVERMIND ERRROR: At least one effects definition contains a duplicate key"
+        throw new Error("Merge conflict: at least one effects definition contains a duplicate key")
       }
       return {
         onInitialize: aggr.onInitialize,


### PR DESCRIPTION
I noticed that I could merge state, actions and effects that had properties with the same names. One set will just get overwritten in the .reduce() of the config.merge function. I have therefore thrown an error should the merge function encounter any duplicates. 