### PR TITLE
Resolve unknown actions as such

### DIFF
--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -182,7 +182,7 @@ export type ResolveActions<
           : (value: TActionValue<Actions[T]>) => ReturnType<Actions[T]>
         : Actions[T] extends NestedActions
         ? ResolveActions<Actions[T]>
-        : never
+        : unknown
     }
 
 type NestedMockActions =
@@ -211,5 +211,5 @@ export type ResolveMockActions<
           : (value: TActionValue<Actions[T]>) => Promise<MockResult>
         : Actions[T] extends NestedMockActions
         ? ResolveMockActions<Actions[T]>
-        : undefined
+        : unknown
     }


### PR DESCRIPTION
Resolving actions that don't exist to either `never` or `undefined` won't prevent calling them or passing them as parameters. But resolving them as `unknown` will do so.