### PR TITLE
WIP: VS Code extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1099,6 +1099,11 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
       "dev": true
     },
+    "@types/vscode": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.35.0.tgz",
+      "integrity": "sha512-Iyliuu8Hv4qy4TEaevQzChh9UsTEcuaKdcHXBbvJnoJSF5Td2yNENOrPK+vuOaXJJBhQZb4BNJKOxt6caaQR8A=="
+    },
     "@types/ws": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
@@ -1373,6 +1378,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "6.8.1",
@@ -3490,6 +3503,11 @@
           "dev": true
         }
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -6113,6 +6131,14 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
       "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
     },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -8641,6 +8667,11 @@
         "unicode-trie": "^0.3.1"
       }
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -9543,6 +9574,30 @@
         }
       }
     },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "http-proxy-middleware": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
@@ -9870,6 +9925,25 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "husky": {
       "version": "0.14.3",
@@ -12905,6 +12979,79 @@
       "dev": true,
       "requires": {
         "mkdirp": "*"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
       }
     },
     "move-concurrently": {
@@ -19457,8 +19604,7 @@
     "querystringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
-      "dev": true
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
     },
     "quote-stream": {
       "version": "1.0.2",
@@ -20382,8 +20528,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.10.0",
@@ -23243,7 +23388,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
       "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -23359,6 +23503,45 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
+      }
+    },
+    "vscode": {
+      "version": "1.1.34",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.34.tgz",
+      "integrity": "sha512-GuT3tCT2N5Qp26VG4C+iGmWMgg/MuqtY5G5TSOT3U/X6pgjM9LFulJEeqpyf6gdzpI4VyU3ZN/lWPo54UFPuQg==",
+      "requires": {
+        "glob": "^7.1.2",
+        "mocha": "^4.0.1",
+        "request": "^2.88.0",
+        "semver": "^5.4.1",
+        "source-map-support": "^0.5.0",
+        "url-parse": "^1.4.4",
+        "vscode-test": "^0.4.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.12",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "vscode-test": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+      "requires": {
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1"
       }
     },
     "vue": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@types/node": "10.5.1",
+    "@types/vscode": "^1.35.0",
+    "@types/ws": "6.0.1",
     "axios": "0.18.0",
     "color": "3.0.0",
     "color-hash": "1.0.3",
@@ -52,11 +54,11 @@
     "react-icons": "^3.5.0",
     "styled-components": "3.3.3",
     "tslib": "1.9.3",
+    "vscode": "^1.1.34",
     "vue": "2.5.16",
     "vue-hot-reload-api": "2.3.0",
     "vue-styled-components": "1.3.0",
-    "ws": "7.0.0",
-    "@types/ws": "6.0.1"
+    "ws": "7.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",

--- a/packages/node_modules/overmind-devtools-client/DevtoolBackend.js
+++ b/packages/node_modules/overmind-devtools-client/DevtoolBackend.js
@@ -1,15 +1,18 @@
 const WebSocket = require('ws')
 
+
+
 class DevtoolBackend {
   constructor(options) {
     this.options = options
-
     this.onError = this.onError.bind(this)
+
     this.onClientConnection = this.onClientConnection.bind(this)
     this.onDevtoolConnection = this.onDevtoolConnection.bind(this)
+    this.onConnection = this.onConnection.bind(this)
     this.onClientMessage = this.onClientMessage.bind(this)
     this.onDevtoolMessage = this.onDevtoolMessage.bind(this)
-
+    
     this.devtoolServer = new WebSocket.Server(
       {
         port: options.port,
@@ -17,8 +20,19 @@ class DevtoolBackend {
       () => {}
     )
 
-    this.devtoolServer.on('connection', this.onDevtoolConnection)
+    this.devtoolServer.on('connection', this.onConnection)
+    this.devtoolServer.on('error', this.onError)
   }
+
+  onConnection(ws, req) {
+    // devtools connects with ?devtools=1 in url
+    if (req.url.indexOf("devtools") !== -1) {
+      this.onDevtoolConnection(ws, req)
+    } else {
+      this.onClientConnection(ws, req)
+    }
+  }
+
   onDevtoolConnection(ws) {
     this.devtoolSocket = ws
     this.devtoolSocket.on('message', this.onDevtoolMessage)
@@ -46,14 +60,16 @@ class DevtoolBackend {
         this.options.onRelaunch()
         break
       case 'connect':
-        this.createClientServer(parsedMessage.data)
+          console.log('TODO: connect'); // TODO: Let devtools know that they are connected to server?
+        // this.createClientServer(parsedMessage.data)
         break
       default:
         this.clientSocket.send(JSON.stringify(parsedMessage.data))
     }
   }
   onError() {
-    this.devtoolServer.emit('port:exists')
+    console.log('TODO: onError');
+    // this.devtoolServer.emit('port:exists')
   }
   onClientConnection(ws) {
     this.clientSocket = ws
@@ -81,23 +97,6 @@ class DevtoolBackend {
         })
       )
     }
-  }
-  createClientServer(port) {
-    if (this.clientPort === Number(port)) {
-      return
-    }
-
-    if (this.clientServer) {
-      this.clientServer.close()
-    }
-
-    this.clientPort = Number(port)
-    this.clientServer = new WebSocket.Server(
-      { port: this.clientPort },
-      () => {}
-    )
-    this.clientServer.on('connection', this.onClientConnection)
-    this.clientServer.on('error', this.onError)
   }
 }
 

--- a/packages/node_modules/overmind-devtools-client/src/BackendConnector.ts
+++ b/packages/node_modules/overmind-devtools-client/src/BackendConnector.ts
@@ -12,7 +12,7 @@ class WebsocketConnector {
   private callbacks: {
     [event: string]: Function[]
   } = {}
-  private socket = new WebSocket('ws://localhost:1040')
+  private socket = new WebSocket('ws://localhost:3031?devtools=1') // TODO should be able to configure
   private messagesBeforeConnected: Array<[string, any, any]> = []
   private isOpen = false
   constructor() {

--- a/packages/node_modules/overmind-devtools-vscode/.gitignore
+++ b/packages/node_modules/overmind-devtools-vscode/.gitignore
@@ -1,0 +1,4 @@
+out
+node_modules
+.vscode-test/
+*.vsix

--- a/packages/node_modules/overmind-devtools-vscode/.vscodeignore
+++ b/packages/node_modules/overmind-devtools-vscode/.vscodeignore
@@ -1,0 +1,10 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+src/**
+.gitignore
+vsc-extension-quickstart.md
+**/tsconfig.json
+**/tslint.json
+**/*.map
+**/*.ts

--- a/packages/node_modules/overmind-devtools-vscode/CHANGELOG.md
+++ b/packages/node_modules/overmind-devtools-vscode/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to the "overmind-devtools" extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+- Initial release

--- a/packages/node_modules/overmind-devtools-vscode/README.md
+++ b/packages/node_modules/overmind-devtools-vscode/README.md
@@ -1,0 +1,65 @@
+# overmind-devtools README
+
+This is the README for your extension "overmind-devtools". After writing up a brief description, we recommend including the following sections.
+
+## Features
+
+Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+
+For example if there is an image subfolder under your extension project workspace:
+
+\!\[feature X\]\(images/feature-x.png\)
+
+> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+
+## Requirements
+
+If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+
+## Extension Settings
+
+Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
+
+For example:
+
+This extension contributes the following settings:
+
+* `myExtension.enable`: enable/disable this extension
+* `myExtension.thing`: set to `blah` to do something
+
+## Known Issues
+
+Calling out known issues can help limit users opening duplicate issues against your extension.
+
+## Release Notes
+
+Users appreciate release notes as you update your extension.
+
+### 1.0.0
+
+Initial release of ...
+
+### 1.0.1
+
+Fixed issue #.
+
+### 1.1.0
+
+Added features X, Y, and Z.
+
+-----------------------------------------------------------------------------------------------------------
+
+## Working with Markdown
+
+**Note:** You can author your README using Visual Studio Code.  Here are some useful editor keyboard shortcuts:
+
+* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
+* Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
+* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+
+### For more information
+
+* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
+
+**Enjoy!**

--- a/packages/node_modules/overmind-devtools-vscode/README.md
+++ b/packages/node_modules/overmind-devtools-vscode/README.md
@@ -1,65 +1,41 @@
-# overmind-devtools README
+<h1 align="center">
+  <br>
+    <img src="https://github.com/cerebral/overmind/blob/next/logo.png?raw=true" alt="logo" width="100">
+  <br>
+  Overmind Devtools for VS Code
+  <br>
+  <br>
+</h1>
 
-This is the README for your extension "overmind-devtools". After writing up a brief description, we recommend including the following sections.
+<h4 align="center">Devtools for Overmind - <a href="https://overmindjs.org/">https://overmindjs.org/</a></h4>
+
+## Getting started
+
+1. Grab extension from [marketplace](https://marketplace.visualstudio.com/items?itemName=overmind.devtools)
+2. Run the command `Overmind Devtools: Start`
+
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+- explore state
+- etc etc
 
-For example if there is an image subfolder under your extension project workspace:
-
-\!\[feature X\]\(images/feature-x.png\)
-
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
-
-## Requirements
-
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
 This extension contributes the following settings:
 
-* `myExtension.enable`: enable/disable this extension
-* `myExtension.thing`: set to `blah` to do something
+* `overmind-devtools.port`: port for devtools backend server
+* `overmind-devtools.verbose`: toggle verbose logging
 
 ## Known Issues
 
-Calling out known issues can help limit users opening duplicate issues against your extension.
+* Relaunch does not work.
+* overmind-devtools-client dist files are manually copied into overmind-devtools-vscode
+* storage in overmind-devtools-vscode is a dummy, and must be updated to VSCode APIs
+* DevtoolsPanel needs a refactor and must implement more VS apis
+
 
 ## Release Notes
 
-Users appreciate release notes as you update your extension.
-
-### 1.0.0
-
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
-
------------------------------------------------------------------------------------------------------------
-
-## Working with Markdown
-
-**Note:** You can author your README using Visual Studio Code.  Here are some useful editor keyboard shortcuts:
-
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
-* Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
-
-### For more information
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**
+TODO

--- a/packages/node_modules/overmind-devtools-vscode/devtoolsDist/index.html
+++ b/packages/node_modules/overmind-devtools-vscode/devtoolsDist/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Code+Pro"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Nunito:400,700"
+      rel="stylesheet"
+    />
+  </head>
+  <body><script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/packages/node_modules/overmind-devtools-vscode/package.json
+++ b/packages/node_modules/overmind-devtools-vscode/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "overmind-devtools-vscode",
+  "displayName": "Overmind Devtools VSCode",
+  "description": "Devtools for Overmind",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.35.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:overmind-devtools.start",
+    "onWebviewPanel:overmindDevtools"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Overmind Devtools",
+      "type": "object",
+      "properties": {
+        "overmind-devtools.port": {
+          "default": 3031,
+          "description": "The default port for the internal relay server",
+          "type": "number"
+        },
+        "overmind-devtools.verbose": {
+          "default": "",
+          "description": "Toggles verbose logging",
+          "type": "boolean"
+        }
+      }
+    },
+    "commands": [
+      {
+        "category": "Overmind Devtools",
+        "command": "overmind-devtools.start",
+        "title": "Start"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "yarn run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "yarn run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^10.12.21",
+    "tslint": "^5.12.1",
+    "typescript": "^3.3.1",
+    "vscode": "^1.1.34"
+  },
+  "dependencies": {
+    "ws": "^7.0.0"
+  }
+}

--- a/packages/node_modules/overmind-devtools-vscode/package.json
+++ b/packages/node_modules/overmind-devtools-vscode/package.json
@@ -21,7 +21,7 @@
       "properties": {
         "overmind-devtools.port": {
           "default": 3031,
-          "description": "The default port for the internal relay server",
+          "description": "Port for devtools backend server",
           "type": "number"
         },
         "overmind-devtools.verbose": {

--- a/packages/node_modules/overmind-devtools-vscode/src/DevtoolsPanel.ts
+++ b/packages/node_modules/overmind-devtools-vscode/src/DevtoolsPanel.ts
@@ -1,0 +1,114 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { log } from "./utils/Logger";
+
+export class DevtoolsPanel {
+  public static currentPanel: DevtoolsPanel | undefined;
+
+  public static viewType = "overmindDevtools";
+
+  // keeps track of location for overmind-devetools js bundle
+  public static scriptFile: any = null;
+
+  private readonly _panel: vscode.WebviewPanel;
+
+  private _disposables: vscode.Disposable[] = [];
+
+  private constructor(panel: vscode.WebviewPanel, extensionPath: string) {
+    this._panel = panel;
+    this.update();
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    this._panel.onDidChangeViewState(
+      e => {
+        if (this._panel.visible) {
+          this.update();
+        }
+      },
+      null,
+      this._disposables
+    );
+
+    this._panel.webview.onDidReceiveMessage(
+      message => {
+        switch (message.command) {
+          case "alert":
+            vscode.window.showErrorMessage(message.text);
+            
+        }
+      },
+      null,
+      this._disposables
+    );
+  }
+
+  dispose(): any {
+    DevtoolsPanel.currentPanel = undefined;
+    this._panel.dispose();
+    while (this._disposables.length) {
+      const x = this._disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+
+  private update() {
+    log("Extension.update");
+    this._panel.webview.html = this.getHtmlForWevbiew();
+  }
+
+  private getHtmlForWevbiew(): string {
+    return `<!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <title>Document</title>
+        <link
+          href="https://fonts.googleapis.com/css?family=Source+Code+Pro"
+          rel="stylesheet"
+        />
+        <link
+          href="https://fonts.googleapis.com/css?family=Nunito:400,700"
+          rel="stylesheet"
+        />
+      </head>
+      <body>
+      <script type="text/javascript" src="${DevtoolsPanel.scriptFile}"></script>
+      </body>
+    </html>
+    `;
+  }
+
+  static createOrShow(extensionPath: string) {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined;
+
+    if (DevtoolsPanel.currentPanel) {
+      DevtoolsPanel.currentPanel._panel.reveal(column);
+      return;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      DevtoolsPanel.viewType,
+      "Overmind",
+      column || vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.file(path.join(extensionPath, "devtoolsDist"))
+        ]
+      }
+    );
+
+    DevtoolsPanel.currentPanel = new DevtoolsPanel(panel, extensionPath);
+  }
+
+  static revive(webViewPanel: vscode.WebviewPanel, extensionPath: string) {
+    DevtoolsPanel.currentPanel = new DevtoolsPanel(webViewPanel, extensionPath);
+  }
+}

--- a/packages/node_modules/overmind-devtools-vscode/src/extension.ts
+++ b/packages/node_modules/overmind-devtools-vscode/src/extension.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode'
+import { DevtoolsPanel } from './DevtoolsPanel'
+import * as path from 'path'
+
+import { log } from './utils/Logger'
+
+class TempStorage {
+  private storage: any = {}
+  public get(key: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      resolve(this.storage[key] || undefined)
+    })
+  }
+
+  public set(key: string, value: any) {
+    return new Promise((resolve, reject) => {
+      this.storage[key] = value
+      resolve()
+    })
+  }
+
+  public clear() {
+    return new Promise((resolve, reject) => {
+      this.storage = {}
+      resolve()
+    })
+  }
+}
+
+const storage = new TempStorage()
+
+const DevtoolBackend = require('overmind-devtools-client/DevtoolBackend')
+DevtoolBackend.create({
+  port: 3031,
+  onRelaunch() {
+    console.log('relaunch')
+  },
+  storage,
+})
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('overmind-devtools.start', () => {
+      const onDiskPath = vscode.Uri.file(
+        path.join(context.extensionPath, 'devtoolsDist', 'bundle.js')
+      )
+      const scriptFile = onDiskPath.with({ scheme: 'vscode-resource' })
+
+      DevtoolsPanel.scriptFile = scriptFile
+      DevtoolsPanel.createOrShow(context.extensionPath) // refactor to keep local reference to panel
+    })
+  )
+
+  // TODO: what does this do?
+  if (vscode.window.registerWebviewPanelSerializer) {
+    vscode.window.registerWebviewPanelSerializer(DevtoolsPanel.viewType, {
+      async deserializeWebviewPanel(
+        webViewPanel: vscode.WebviewPanel,
+        state: any
+      ) {
+        DevtoolsPanel.revive(webViewPanel, context.extensionPath)
+      },
+    })
+  }
+}
+
+// this method is called when your extension is deactivated
+export function deactivate() {
+  log('Extension deactivated')
+}

--- a/packages/node_modules/overmind-devtools-vscode/src/index.ts
+++ b/packages/node_modules/overmind-devtools-vscode/src/index.ts
@@ -1,0 +1,23 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testsRoot: string, clb: (error: Error, failures?: number) => void): void
+// that the extension host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+import * as testRunner from 'vscode/lib/testrunner';
+
+// You can directly control Mocha options by configuring the test runner below
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options
+// for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/packages/node_modules/overmind-devtools-vscode/src/utils/Logger.ts
+++ b/packages/node_modules/overmind-devtools-vscode/src/utils/Logger.ts
@@ -1,0 +1,6 @@
+// const isVerbose = vscode.workspace.getConfiguration().get('overmind-devtools.verbose');
+// TODO: check verbose in config, do not log if set
+export function log(...args:any)
+{
+    console.log(...args);
+}

--- a/packages/node_modules/overmind-devtools-vscode/tsconfig.json
+++ b/packages/node_modules/overmind-devtools-vscode/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "inlineSources": true,
+
+    "target": "es6",
+    "outDir": "out",
+    "lib": ["es6"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true /* enable all strict type-checking options */
+    /* Additional Checks */
+    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+  },
+  "include": ["src"],
+
+  "exclude": ["node_modules", ".vscode-test"]
+}

--- a/packages/node_modules/overmind-devtools-vscode/vsc-extension-quickstart.md
+++ b/packages/node_modules/overmind-devtools-vscode/vsc-extension-quickstart.md
@@ -1,0 +1,41 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your extension and command.
+  * The sample plugin registers a command and defines its title and command name. With this information VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
+* `src/extension.ts` - this is the main file where you will provide the implementation of your command.
+  * The file exports one function, `activate`, which is called the very first time your extension is activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
+  * We pass the function containing the implementation of the command as the second parameter to `registerCommand`.
+
+## Get up and running straight away
+
+* Press `F5` to open a new window with your extension loaded.
+* Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
+* Set breakpoints in your code inside `src/extension.ts` to debug your extension.
+* Find output from your extension in the debug console.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+## Explore the API
+
+* You can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`.
+
+## Run tests
+
+* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Extension Tests`.
+* Press `F5` to run the tests in a new window with your extension loaded.
+* See the output of the test result in the debug console.
+* Make changes to `test/extension.test.ts` or create new test files inside the `test` folder.
+  * By convention, the test runner will only consider files matching the name pattern `**.test.ts`.
+  * You can create folders inside the `test` folder to structure your tests any way you want.
+
+## Go further
+
+ * Reduce the extension size and improve the startup time by [bundling your extension](https://code.visualstudio.com/api/working-with-extensions/testing-extension).
+ * [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VSCode extension marketplace.
+ * Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).


### PR DESCRIPTION
**Heads up: WIP**

Opening this for discussion and input.

If you want to play around with this, open `overmind-devtools-vscode` in VS Code and press run. This will start the `Extension Development Environment`. Open command palette (osx: cmd + shift + p) and search for `overmind`. This should open the extension and show the `Waiting for an app to connect...` screen.

Fire up any overmind-app that connects to devtools on port 3031. This should bring up the devtools, and any actions taken in the app should be reflected.

**Known issues:**

- Relaunch does not work. 
- overmind-devtools-client dist files are manually copied into overmind-devtools-vscode
- storage in overmind-devtools-vscode is a dummy, and must be updated to VSCode APIs (https://code.visualstudio.com/api/references/vscode-api#Memento ?)
- DevtoolsPanel needs a refactor and must implement more VS apis

**Bundling and publishing**
Have not looked much into this yet, so some resources for future reference:
- http://jasonpoon.ca/continuous-delivery-of-visual-studio-code-extensions/
- https://code.visualstudio.com/api/working-with-extensions/publishing-extension
- https://code.visualstudio.com/api/working-with-extensions/bundling-extension
