### PR TITLE
Reduce production bundle size by 1/3

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -38,9 +38,7 @@ import {
   MockedEventEmitter,
   makeStringifySafeMutations,
   mergeState,
-  IS_DEVELOPMENT,
   IS_TEST,
-  IS_PRODUCTION,
   IS_OPERATOR,
   getFunctionName,
   getActionPaths,
@@ -211,7 +209,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     const name = options.name || 'OvermindApp'
 
     if (
-      IS_DEVELOPMENT &&
+      (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') &&
       mode.mode === MODE_DEFAULT &&
       options.hotReloading !== false &&
       !(process && process.title && process.title.includes('node'))
@@ -238,7 +236,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     const proxyStateTree = this.createProxyStateTree(
       configuration,
       eventHub,
-      mode.mode === MODE_SSR ? false : IS_DEVELOPMENT
+      mode.mode === MODE_SSR ? false : process.env.NODE_ENV === 'development'
     )
 
     this.originalConfiguration = configuration
@@ -253,7 +251,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     }
 
     if (
-      IS_DEVELOPMENT &&
+      process.env.NODE_ENV === 'development' &&
       mode.mode === MODE_DEFAULT &&
       typeof window !== 'undefined'
     ) {
@@ -302,7 +300,7 @@ export class Overmind<ThisConfig extends IConfiguration>
       }
     }
 
-    if (IS_PRODUCTION && mode.mode === MODE_DEFAULT) {
+    if (process.env.NODE_ENV === 'production' && mode.mode === MODE_DEFAULT) {
       eventHub.on(EventType.OPERATOR_ASYNC, () => {
         proxyStateTree.getMutationTree().flush(true)
       })
@@ -389,7 +387,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     return proxyStateTree
   }
   private createExecution(name, action, parentExecution) {
-    if (IS_PRODUCTION) {
+    if (process.env.NODE_ENV === 'production') {
       return ({
         [EXECUTION]: true,
         parentExecution,
@@ -483,7 +481,7 @@ export class Overmind<ThisConfig extends IConfiguration>
       boundExecution =
         boundExecution && boundExecution[EXECUTION] ? boundExecution : undefined
 
-      if (IS_PRODUCTION || action[IS_OPERATOR]) {
+      if (process.env.NODE_ENV === 'production' || action[IS_OPERATOR]) {
         const execution = this.createExecution(name, action, boundExecution)
         this.eventHub.emit(EventType.ACTION_START, {
           ...execution,
@@ -622,7 +620,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     return actionFunc
   }
   private trackEffects(effects = {}, execution) {
-    if (IS_PRODUCTION) {
+    if (process.env.NODE_ENV === 'production') {
       return effects
     }
 
@@ -799,7 +797,7 @@ export class Overmind<ThisConfig extends IConfiguration>
       } else if (typeof value === 'function') {
         aggr[key] = new Derived(value)
 
-        if (IS_DEVELOPMENT) {
+        if (process.env.NODE_ENV === 'development') {
           this.derivedReferences.push(aggr[key])
         }
       } else {

--- a/packages/node_modules/overmind/src/operator.ts
+++ b/packages/node_modules/overmind/src/operator.ts
@@ -1,5 +1,4 @@
 import {
-  IS_PRODUCTION,
   IS_OPERATOR,
   makeStringifySafeMutations,
   createActionsProxy,
@@ -10,7 +9,7 @@ import { safeValue } from './Devtools'
 import { IContext, IConfiguration, IOperator } from './types'
 
 export function operatorStarted(type, arg, context) {
-  if (IS_PRODUCTION) {
+  if (process.env.NODE_ENV === 'production') {
     return
   }
   const name =
@@ -32,7 +31,7 @@ export function operatorStopped(
     isSkipped?: boolean
   } = {}
 ) {
-  if (IS_PRODUCTION) {
+  if (process.env.NODE_ENV === 'production') {
     if (value instanceof Promise) {
       context.execution.emit(EventType.OPERATOR_ASYNC, {
         ...context.execution,
@@ -74,7 +73,7 @@ export function operatorStopped(
 }
 
 export function createContext(context, value, path?) {
-  if (IS_PRODUCTION) {
+  if (process.env.NODE_ENV === 'production') {
     return {
       ...context,
       value,
@@ -103,7 +102,7 @@ export function createContext(context, value, path?) {
 }
 
 export function createNextPath(next) {
-  if (IS_PRODUCTION) {
+  if (process.env.NODE_ENV === 'production') {
     return next
   }
 
@@ -235,7 +234,7 @@ export function createMutationOperator<ThisConfig extends IConfiguration>(
   const operator = (err, context, next, final) => {
     operatorStarted(type, name, context)
     const mutationTree = context.execution.getMutationTree()
-    if (!IS_PRODUCTION) {
+    if (!(process.env.NODE_ENV === 'production')) {
       mutationTree.onMutation((mutation) => {
         context.execution.emit(EventType.MUTATIONS, {
           ...context.execution,
@@ -252,7 +251,7 @@ export function createMutationOperator<ThisConfig extends IConfiguration>(
           effects: context.effects,
           actions: context.actions,
         },
-        IS_PRODUCTION
+        process.env.NODE_ENV === 'production'
           ? context.value
           : context.execution.scopeValue(context.value, mutationTree),
         (err, value, options = {}) => {
@@ -283,7 +282,7 @@ export function createMutationOperator<ThisConfig extends IConfiguration>(
         }
       )
 
-      if (!IS_PRODUCTION) {
+      if (!(process.env.NODE_ENV === 'production')) {
         let pendingFlush
         mutationTree.onMutation(() => {
           if (pendingFlush) {

--- a/packages/node_modules/overmind/src/utils.ts
+++ b/packages/node_modules/overmind/src/utils.ts
@@ -3,9 +3,6 @@ import { IMutation } from 'proxy-state-tree'
 import { safeValues } from './Devtools'
 
 export const IS_TEST = process.env.NODE_ENV === 'test'
-export const IS_PRODUCTION = process.env.NODE_ENV === 'production'
-export const IS_DEVELOPMENT =
-  !process.env.NODE_ENV || process.env.NODE_ENV === 'development'
 export const IS_OPERATOR = Symbol('operator')
 export const ORIGINAL_ACTIONS = Symbol('origina_actions')
 export const EXECUTION = Symbol('execution')


### PR DESCRIPTION
I noticed while reading the overmind code that the `IS_PRODUCTION` and `IS_DEVELOPMENT` checks where moved to the utils file. 
As a consequence webpack isn't able to strip the development stuff in production anymore because it can't currently resolve these kinds of dependencies. 

Just to see how much of an impact this has I moved all these checks back into the places `IS_PRODUCTION` and `IS_DEVELOPMENT` where used 
and tested with a minimal production build:

#### index.js
```js
import { Overmind } from 'overmind'
window.app = new Overmind({})
```

#### webpack.config.js
```js
const path = require('path')
const TerserPlugin = require('terser-webpack-plugin')

module.exports = {
  mode: 'production',
  entry: path.resolve('index.js'),
  output: {
    path: path.resolve('dist'),
    filename: 'bundle.js',
  },
  optimization: {
    minimizer: [
      new TerserPlugin({
        test: /\.js(\?.*)?$/i,
        parallel: true,
        sourceMap: true,
      }),
    ],
  },
  module: {
    rules: [
      {
        test: /\.js$/,
        loader: 'babel-loader',
        include: path.resolve('src'),
        options: {
          presets: ['@babel/preset-env'],
        },
      },
    ],
  },
}
```


As of `overmind@19.0.0-1561670210327` I am getting `29.6 KiB` (8.54 KiB gzip)
After applying these changes and building again I am getting `18.8 KiB` (5.64 KiB gzip).

<strong>This is a reduction of ~36% (~33% gzip).</strong>

I think moving these check back into place is worth 1/3 size reduction
