### PR TITLE
removed inline-source-maps from production build of devtools-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12658,16 +12658,6 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -18937,6 +18927,16 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
@@ -21701,26 +21701,45 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
-      "integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+      "integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
       "dev": true,
       "requires": {
-        "cacache": "^11.0.2",
+        "cacache": "^11.3.2",
         "find-cache-dir": "^2.0.0",
+        "is-wsl": "^1.1.0",
+        "loader-utils": "^1.2.3",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
+        "serialize-javascript": "^1.7.0",
         "source-map": "^0.6.1",
-        "terser": "^3.8.1",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "terser": "^4.0.0",
+        "webpack-sources": "^1.3.0",
+        "worker-farm": "^1.7.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "terser": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+          "integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.19.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.10"
+          }
         }
       }
     },
@@ -23713,6 +23732,15 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "webpack-merge": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
+      "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "repo-cooker": "^6.3.0",
     "rimraf": "2.6.2",
     "source-map-loader": "0.2.4",
-    "terser-webpack-plugin": "1.2.1",
+    "terser-webpack-plugin": "1.3.0",
     "ts-jest": "23.10.4",
     "ts-loader": "4.4.2",
     "tslib": "1.9.3",
@@ -116,7 +116,8 @@
     "vue-template-compiler": "2.5.16",
     "webpack": "4.28.4",
     "webpack-cli": "3.1.2",
-    "webpack-dev-server": "3.1.11"
+    "webpack-dev-server": "3.1.11",
+    "webpack-merge": "4.2.1"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/packages/node_modules/overmind-devtools-client/package.json
+++ b/packages/node_modules/overmind-devtools-client/package.json
@@ -7,7 +7,7 @@
 	"repository": "git+https://github.com/cerebral/overmind.git",
 	"scripts": {
 		"start": "webpack-dev-server",
-		"build": "webpack --mode production",
+		"build": "webpack --config webpack.prod.js",
 		"typecheck": "tsc --noEmit",
 		"test": "jest --runInBand",
 		"test:watch": "jest --watch --updateSnapshot --coverage false",
@@ -30,6 +30,8 @@
 	"devDependencies": {
     "@types/node": "^10.12.21",
     "@types/ws": "6.0.1",
-		"@babel/plugin-proposal-class-properties": "^7.3.4"
+		"@babel/plugin-proposal-class-properties": "^7.3.4",
+    "terser-webpack-plugin": "^1.3.0",
+    "webpack-merge": "^4.2.1"
 	}
 }

--- a/packages/node_modules/overmind-devtools-client/webpack.prod.js
+++ b/packages/node_modules/overmind-devtools-client/webpack.prod.js
@@ -1,0 +1,18 @@
+const merge = require('webpack-merge')
+const base = require('./webpack.config.js')
+
+const TerserPlugin = require('terser-webpack-plugin')
+
+module.exports = merge(base, {
+  devtool: 'source-map',
+  mode: 'production',
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        test: /\.js(\?.*)?$/i,
+        parallel: true,
+        sourceMap: true,
+      }),
+    ],
+  },
+})


### PR DESCRIPTION
While we are at it. I did another pass optimising the bundle size of the devtools-client. Before you still had 
`inline-source-maps` turned on in productions. I disabled that know and the bundle size 
dropped from `2.91 MiB` to `238 KiB`. 