### PR TITLE
perf(overmind): completely remove devtools in production

### DIFF
--- a/packages/node_modules/overmind/src/Devtools.ts
+++ b/packages/node_modules/overmind/src/Devtools.ts
@@ -39,38 +39,6 @@ export function safeValues(values) {
   return values.map(safeValue)
 }
 
-function throttle(func, wait, options?) {
-  var context, args, result
-  var timeout: NodeJS.Timeout | null = null
-  var previous = 0
-  if (!options) options = {}
-  var later = function() {
-    previous = options.leading === false ? 0 : Date.now()
-    timeout = null
-    result = func.apply(context, args)
-    if (!timeout) context = args = null
-  }
-  return function() {
-    var now = Date.now()
-    if (!previous && options.leading === false) previous = now
-    var remaining = wait - (now - previous)
-    context = this
-    args = arguments
-    if (remaining <= 0 || remaining > wait) {
-      if (timeout) {
-        clearTimeout(timeout)
-        timeout = null
-      }
-      previous = now
-      result = func.apply(context, args)
-      if (!timeout) context = args = null
-    } else if (!timeout && options.trailing !== false) {
-      timeout = setTimeout(later, remaining)
-    }
-    return result
-  }
-}
-
 export class Devtools {
   private buffer: string[] = []
   private ws: WebSocket

--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -702,6 +702,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     })
   }
   private initializeDevtools(host, name, eventHub, initialState, actions) {
+    if (process.env.NODE_ENV === 'production') return
     const devtools = new Devtools(name)
     devtools.connect(
       host,


### PR DESCRIPTION
We might not want this but I was done with it anyways. 

Removing the devtools from a production build is resulting in a little drop in bundle size too. 
Before: `17.9 KiB` (`5.39 KiB` gzip)
After: `16.2 KiB` (`4.81 KiB` gzip)

Not a huge drop like before but still ~9% (~10% gzip) size improvements. 

>I also removed the `throttle` function from `Devtools.ts` because it was unused but that got stripped away by webpack before
so there was no bundle size gain 