### PR TITLE
Spell-check and tweak the guide for fluency

### DIFF
--- a/packages/overmind-website/guides/beginner/01_quickstart.md
+++ b/packages/overmind-website/guides/beginner/01_quickstart.md
@@ -14,7 +14,7 @@ Now set up a simple application like this:
 h(Example, { name: "guide/quickstart/simple_app" })
 ```
 
-And fire up your application in the browser or whatever environment your user interface is to be consumed by the users.
+And fire up your application in the browser or whatever environment your user interface is to be consumed in by the users.
 
 
 ## VS Code

--- a/packages/overmind-website/guides/beginner/02_getstarted.md
+++ b/packages/overmind-website/guides/beginner/02_getstarted.md
@@ -5,11 +5,11 @@ If you are moving from an existing state management solution, please read the re
 To get started with Overmind you have to set up a project. You can do this with whatever tool your framework of choice provides or you can use [webpack](https://webpack.js.org/) or [parceljs](https://parceljs.org/). You can also use [codesandbox.io](https://codesandbox.io/) to play around with Overmind directly in the browser.
 
 ```marksy
-h(Notice, null, "Due to using the Proxy feature of JavaScript, Overmind does not support **Internet Explorer 11**. Though did you know IE 11 mode is coming to [Microsofts next browser](https://www.pcworld.com/article/3393198/microsoft-edge-ie-mode.html)?")
+h(Notice, null, "Due to using the Proxy feature of JavaScript, Overmind does not support **Internet Explorer 11**. Though did you know IE 11 mode is coming to [Microsoft's next browser](https://www.pcworld.com/article/3393198/microsoft-edge-ie-mode.html)?")
 ```
 
 
-When you have your project up and running install the Overmind dependency by using [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/en/):
+When you have your project up and running, install the Overmind dependency by using [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/en/):
 
 ```marksy
 h(Example, { name: "guide/getstarted/install" })
@@ -41,7 +41,7 @@ The devtools should respond when you open up your application:
 
 ![open_devtool](/images/devtool_state.png)
 
-Now that we have our state in place, lets change it.
+Now that we have our state in place, let's change it.
 
 ## Changing state
 
@@ -58,13 +58,13 @@ To trigger this action, go to the **actions** tab in the development tool and ru
 
 ## Creating effects
 
- State management tools has a tendency to end their introduction here, but Overmind helps you manage one more important ingredient, **effects**. An effect, or side effect, is everything from doing http requests to storing data in local storage. What Overmind helps you with is separating the generic low level APIs of using effects from your actual application logic inside actions. Let us look at an example. We are simply going to grab a random number from "somewhere out there":
+State management tools have a tendency to end their introduction here, but Overmind helps you manage one more important ingredient, **effects**. An effect, or side effect, is everything from doing HTTP requests to storing data in local storage. What Overmind helps you with is separating the generic low level APIs of using effects from your actual application logic inside actions. Let us look at an example. We are simply going to grab a random number from "somewhere out there":
 
 ```marksy
 h(Example, { name: "guide/getstarted/effect" })
 ```
 
-As you can see we separated the low level generic code of creating a random number from our actual application logic in the action. Think of effects as the API you custom tailor to your application. There are several benefits to effects, which you can read about later, but the really important thing is that you separate the tools you are using from your actual application. That means you can at any time replace this custom random number generator with some existing tool or maybe you will grab it from the server? This is also true for everything else. If your application needs posts you will create a **getPosts** effect. It does not matter to the application if this comes from a restful API, graphql or whatever other source. It is an implementation detail.
+As you can see we separated the low level generic code of creating a random number from our actual application logic in the action. Think of effects as the API you custom tailor to your application. There are several benefits to effects, which you can read about later, but the really important thing is that you separate the tools you are using from your actual application. That means you can at any time replace this custom random number generator with some existing tool or maybe you will grab it from the server? This is also true for everything else. If your application needs posts you will create a **getPosts** effect. It does not matter to the application if this comes from a restful API, GraphQL or whatever other source. It is an implementation detail.
 
 With our effect in place, let us run the actions again:
 
@@ -78,7 +78,7 @@ Now that we know our application works as expected we can actually produce the U
 h(Example, { name: "guide/getstarted/connectapp" })
 ```
 
-Now you can run the actions by clicking the buttons in the UI and the devtools continues to track their execution giving you valuable insight into what happens inside your app.
+Now you can run the actions by clicking the buttons in the UI and the devtool continues to track their execution giving you valuable insight into what happens inside your app.
 
 ## Hot Module Replacement
 
@@ -86,4 +86,4 @@ A popular concept introduced by Webpack is [HMR](https://webpack.js.org/concepts
 
 ## Summary
 
-You have now stepped your toes into Overmind. We introduced Overmind with the concept of thinking the UI as an implementation detail, but it is totally up to you have you want to separate the responsibilities of states and logic in your application. Please continue reading guides to learn more about how Overmind scales.
+You have now stepped your toes into Overmind. We introduced Overmind with the concept of thinking of the UI as an implementation detail, but it is totally up to you how you want to separate the responsibilities of states and logic in your application. Please continue reading guides to learn more about how Overmind scales.

--- a/packages/overmind-website/guides/beginner/03_definingstate.md
+++ b/packages/overmind-website/guides/beginner/03_definingstate.md
@@ -1,6 +1,6 @@
 # Defining state
 
-Typically we think of the user interface as the application itself. But the user interface is really just there to allow a user to interact with the application. This interface can be anything. A browser window, native, sensors etc. it does not matter what the interface is, the application is still the same. 
+Typically we think of the user interface as the application itself. But the user interface is really just there to allow a user to interact with the application. This interface can be anything. A browser window, native, sensors etc. It does not matter what the interface is, the application is still the same. 
 
 The mechanism of communicating from the application to the user interface is called **state**. A user interface is created by **transforming** the current state. To communicate from the user interface to the application an API is exposed, called **actions** in Overmind. Any interaction can trigger an action which changes the state, causing the application to notify the user interface about any updated state.
 
@@ -10,11 +10,11 @@ The mechanism of communicating from the application to the user interface is cal
 
 In JavaScript we can create all sorts of abstractions to describe values, but in Overmind we lean on the core serializable values. These are **objects**, **arrays**, **strings**, **numbers**, **booleans** and **null**. Serializable values means that we can easily convert the state into a string and back again. This is fundamental for creating great developer experiences, passing state between client and server and other features. You can describe any application state with these core values.
 
-Let us talk a litte bit about what each value helps us represent in our application.
+Let us talk a little bit about what each value helps us represent in our application.
 
 ### Naming
 
-Each value needs to sit behind a name. Naming can be difficult, but we have some help. Even though we eventually do want to consume our application through a user interface we ideally want to avoid naming things specifically related to the environment where we show the user interface. Things like **page**, **tabs**, **modal** etc. is specific to a browser experience, maybe realted to a certain size. We want to avoid those names as they should not dictate what elements are to be used with the state, that is up to the user interface to decide later. So here are some generic terms to use instead:
+Each value needs to sit behind a name. Naming can be difficult, but we have some help. Even though we eventually do want to consume our application through a user interface we ideally want to avoid naming things specifically related to the environment where we show the user interface. Things like **page**, **tabs**, **modal** etc. are specific to a browser experience, maybe related to a certain size. We want to avoid those names as they should not dictate which elements are to be used with the state, that is up to the user interface to decide later. So here are some generic terms to use instead:
 
 - page: **mode**
 - tabs: **sections**
@@ -22,7 +22,7 @@ Each value needs to sit behind a name. Naming can be difficult, but we have some
 
 ### Objects
 
-The root value of your state tree is an object, because objects are great for holding other values. An object has keys that points to values. Most of these keys points to values that is the actual state of the application, but these keys can also represent domains of the application. A typical state structure could be:
+The root value of your state tree is an object, because objects are great for holding other values. An object has keys that point to values. Most of these keys point to values that are the actual state of the application, but these keys can also represent domains of the application. A typical state structure could be:
 
 ```marksy
 h(Example, { name: "guide/definingstate/objects" })
@@ -30,44 +30,44 @@ h(Example, { name: "guide/definingstate/objects" })
 
 ### Arrays
 
-Arrays are in a way similar to objects in the sense that they hold other values, but instead of keys pointing to values you have indexes. That means it is ideal for iteration. But more often than not objects are actually better at managing lists of values. We can actually do fine without arrays in our state. It is when we produce the actual user interface that we usually want arrays. You can learn more about this in the [managing lists](/guides/intermediate/01_managinglists) guide.
+Arrays are similar to objects in the sense that they hold other values, but instead of keys pointing to values you have indexes. That means it is ideal for iteration. But more often than not objects are actually better at managing lists of values. We can actually do fine without arrays in our state. It is when we produce the actual user interface that we usually want arrays. You can learn more about this in the [managing lists](/guides/intermediate/01_managinglists) guide.
 
 ### Strings
 
-Strings are of course used to represent text values. Names, descriptions and what not. But strings are also used for ids, types, etc. Strings can be used as values to reference other values. This is an important part in structuring state. For example in our **objects** example above we chose to use an array to represent the modes, using an index to point to the current mode, but we could also do:
+Strings are of course used to represent text values. Names, descriptions and whatnot. But strings are also used for ids, types, etc. Strings can be used as values to reference other values. This is an important part in structuring state. For example in our **objects** example above we chose to use an array to represent the modes, using an index to point to the current mode, but we could also do:
 
 ```marksy
 h(Example, { name: "guide/definingstate/strings" })
 ```
 
-Now we are referencing the current mode with a string. In this scenario you would probably stick with the array, but it is important to highlight that objects allows you to reference things by string, while arrays reference by number.
+Now we are referencing the current mode with a string. In this scenario you would probably stick with the array, but it is important to highlight that objects allow you to reference things by string, while arrays reference by number.
 
 ### Numbers
 
-Numbers of course represents things like counts, age, etc. But just like strings, they can also represent a reference to something in a list. Like we saw in our **objects** example, to define what the current mode of our application is, we can use a number. You could say that referencing things by number works very well when the value behind the number does not change. Our modes will most likely not change and that is why an array and referencing the current mode by number, is perfectly fine.
+Numbers of course represent things like counts, age, etc. But just like strings, they can also represent a reference to something in a list. Like we saw in our **objects** example, to define what the current mode of our application is, we can use a number. You could say that referencing things by number works very well when the value behind the number does not change. Our modes will most likely not change and that is why an array and referencing the current mode by number, is perfectly fine.
 
 ### Booleans
 
-Are things loading or not, is the user logged in or not ? These are typical usages of boolean values. We use booleans to express that something is activated or not. We should not confuse this with **null**, which means "not existing". We should not use **null** in place of a boolean value. We have to use either `true` or `false`.
+Are things loading or not, is the user logged in or not? These are typical uses of boolean values. We use booleans to express that something is activated or not. We should not confuse this with **null**, which means "not existing". We should not use **null** in place of a boolean value. We have to use either `true` or `false`.
 
 ### Null
 
-All values, with the exception of booleans, can also be **null**. Non existing. You can have a non existing object, array, string or number. That means if we have not selected a mode both the string version and number version would have the value **null**.
+All values, with the exception of booleans, can also be **null**. Non-existing. You can have a non-existing object, array, string or number. It means that if we haven't selected a mode, both the string version and number version would have the value **null**.
 
 ## Deriving state
 
 
 ### Getter
 
-A concept in Javascript called a [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) allows you to intercept accessing a property in an object. A getter is just like a plain value, it can be added an removed at any point. Getters does **not** cache the result for that very reason, but whatever state they access is tracked.
+A concept in Javascript called a [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) allows you to intercept accessing a property in an object. A getter is just like a plain value, it can be added or removed at any point. Getters do **not** cache the result for that very reason, but whatever state they access is tracked.
 
 ```marksy
 h(Example, { name: "guide/definingstate/getter" })
 ```
 
-### Cached gettter
+### Cached getter
 
-When you need to do more heavy calculation or combine state from different parts ot the tree you can use a plain function instead. Overmind treats these functions like a **getter**, but the returned value is cached and they can also access the root state of the application. A simple example of this would be:
+When you need to do more heavy calculation or combine state from different parts of the tree you can use a plain function instead. Overmind treats these functions like a **getter**, but the returned value is cached and they can also access the root state of the application. A simple example of this would be:
 
 ```marksy
 h(Example, { name: "guide/definingstate/derived" })
@@ -85,7 +85,7 @@ The first argument of the function is the state the derived function is attached
 That means the function only runs when accessed and the depending state has changed since last access.
 
 ```marksy
-h(Notice, null, "Even though derived state is defined as functions you consume them as plain values. You do not have to call the derived function to get the value. Derived state can not be dynamically added. They have to be defined and live in the tree from start to end of your application lifecycle")
+h(Notice, null, "Even though derived state is defined as functions you consume them as plain values. You do not have to call the derived function to get the value. Derived state can not be dynamically added. They have to be defined and live in the tree from start to end of your application lifecycle.")
 ```
 
 ### Dynamic getter
@@ -98,7 +98,7 @@ h(Example, { name: "guide/definingstate/derived_passvalue" })
 
 ## References
 
-When you add objects and arrays to your state tree, they are labeled with an "address" in the tree. That means if you try to add the same object or array in multiple spots in the tree you will get an error, as they can not have multiple addresses. Typically this indicates that you rather want to create a references to an existing object or array.
+When you add objects and arrays to your state tree, they are labeled with an "address" in the tree. That means if you try to add the same object or array in multiple spots in the tree you will get an error, as they can not have multiple addresses. Typically this indicates that you'd rather want to create a reference to an existing object or array.
 
 So this is an example of how you would **not** want to do it:
 
@@ -106,7 +106,7 @@ So this is an example of how you would **not** want to do it:
 h(Example, { name: "guide/definingstate/reference" })
 ```
 
-You rather change a reference to the user and for example use a **getter** to grab the actual user:
+You'd rather have a reference to the user id, and for example use a **getter** to grab the actual user:
 
 ```marksy
 h(Example, { name: "guide/definingstate/reference_correct" })

--- a/packages/overmind-website/guides/beginner/04_writingapplicationlogic.md
+++ b/packages/overmind-website/guides/beginner/04_writingapplicationlogic.md
@@ -10,7 +10,7 @@ h(Example, { name: "guide/writingapplicationlogic/define" })
 
 ## Using the context
 
-The context has three parts. **state**, **effects** and **actions**. Typically you destructure the context to access these pieces directly.
+The context has three parts: **state**, **effects** and **actions**. Typically you destructure the context to access these pieces directly:
 
 ```marksy
 h(Example, { name: "guide/writingapplicationlogic/using" })
@@ -19,7 +19,7 @@ h(Example, { name: "guide/writingapplicationlogic/using" })
 When you point to either of these you will always point to the "top of the application. That means if you use namespaces or other nested structures the context is always the root context of the application.
 
 ```marksy
-h(Notice, null, "The reason Overmind only has a root context is because isolated contexts/domains creates more harm than good. Specifically when you develop your applicaiton it is very difficult to know exactly how the domains of your application will look like. What state, actions and effects belongs together. By only having a root context you can always point to any domain from any other domain allowing you to easily manage cross domain logic and not having to refactor every time your domain model breaks.")
+h(Notice, null, "The reason Overmind only has a root context is because having isolated contexts/domains creates more harm than good. Specifically when you develop your application it is very difficult to know exactly how the domains of your application will look like and what state, actions and effects belong together. By only having a root context you can always point to any domain from any other domain allowing you to easily manage cross-domain logic, not having to refactor every time your domain model breaks.")
 ```
 
 ## Passing values
@@ -30,7 +30,7 @@ When you call actions you can pass a single value. This value appears as the sec
 h(Example, { name: "guide/writingapplicationlogic/value" })
 ```
 
-When you call an action from an action you do so using the **actions** passed on the context, as this is the evaluated action that can be called.
+When you call an action from an action you do so by using the **actions** passed on the context, as this is the evaluated action that can be called.
 
 ```marksy
 h(Example, { name: "guide/writingapplicationlogic/call" })

--- a/packages/overmind-website/guides/beginner/05_runningsideeffects.md
+++ b/packages/overmind-website/guides/beginner/05_runningsideeffects.md
@@ -1,14 +1,14 @@
 # Running side effects
 
-Developing applications is not only about managing state, but also managing side effects. A side effect is typically exampled with an http request or talking to local storage. In Overmind we just call this **effects**. There are several reasons why you would want to use effects:
+Developing applications is not only about managing state, but also managing side effects. A typical side effect would be an HTTP request or talking to localStorage. In Overmind we just call these **effects**. There are several reasons why you would want to use effects:
 
 1. All the code in your actions will be domain specific, no low level generic APIs
-2. Your actions will have less code and you avoid leaking out things like urls, types etc.
-3. You decouple the underlying tool from the usage of it, meaning that you can replace it at any time without changing your application logic
-4. You can more easily expand functionality of an effect. For example you want to introduce caching or a base url to an http effect
+2. Your actions will have less code and you avoid leaking out things like URLs, types etc.
+3. You decouple the underlying tool from its usage, meaning that you can replace it at any time without changing your application logic
+4. You can more easily expand the functionality of an effect. For example you want to introduce caching or a base URL to an HTTP effect
 5. The devtool tracks its execution
-6. If you write Overmind tests you can easily mock them
-7. You can lazy load the effect, reducing the initial payload of the app
+6. If you write Overmind tests, you can easily mock them
+7. You can lazy-load the effect, reducing the initial payload of the app
 
 ## Exposing an existing tool
 
@@ -18,7 +18,7 @@ Let us just expose the [axios](https://github.com/axios/axios) library as an **h
 h(Example, { name: "guide/runningsideeffects/axios" })
 ```
 
-We are just exporting the existing library from our effects file and include it in the application config. Now Overmind is aware of an **http** effect. It can track it for debugging and all actions and operators will have it injected.
+We are just exporting the existing library from our effects file and including it in the application config. Now Overmind is aware of an **http** effect. It can track it for debugging and all actions and operators will have it injected.
 
 Let us put it to use in an action that grabs the current user of the application.
 
@@ -26,7 +26,7 @@ Let us put it to use in an action that grabs the current user of the application
 h(Example, { name: "guide/runningsideeffects/getuser" })
 ```
 
-That was basically it. As you can see we are exposing some low level details like the http method used and the url. Let us follow the encouraged way of doing things and create our own **api** effect.
+That was basically it. As you can see we are exposing some low level details like the http method used and the URL. Let us follow the encouraged way of doing things and create our own **api** effect.
 
 ## Specific API
 
@@ -44,13 +44,13 @@ h(Example, { name: "guide/runningsideeffects/changestate" })
 
 ## Initializing effects
 
-It can be a good idea to not allow your side effects to initialize when they are defined. This makes sure that they do not leak into tests or server side rendering. For example if you want to use Firebase. Instead of initializing the Firebase application immediately we rather do it behind an **initialize** method:
+It can be a good idea to not allow your side effects to initialize when they are defined. This makes sure that they do not leak into tests or server side rendering. For example if you want to use Firebase, instead of initializing the Firebase application immediately we rather do it behind an **initialize** method:
 
 ```marksy
 h(Example, { name: "guide/runningsideeffects/initialize" })
 ```
 
-We are doing 2 things here:
+We are doing two things here:
 
 1. We use an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) to create a scoped internal variable to be used for that specific effect
 2. We have created an **initialize** method which we can call from the Overmind **onInitialize** action, which runs when the Overmind instance is created
@@ -80,7 +80,7 @@ You can also lazily load your effects in the **initialize** method. Let us say w
 h(Example, { name: "guide/runningsideeffects/lazy" })
 ```
 
-In our initialize we would just have to wait for the initialize to finish before using the API:
+In our initialize() we would just have to wait for the initialization to finish before using the API:
 
 
 ```marksy
@@ -101,4 +101,4 @@ h(Example, { name: "guide/runningsideeffects/class" })
 We export an instance of our **Api** to the application. This allows us to also create instances in isolation for testing purposes, making sure our Api class works as we expect.
 
 ## Summary
-Importing side effects directly into your code should be considered bad practice. If you think about it from an application standpoint it is kinda weird that it runs http verb methods with a string url. It is better to create an abstraction around it to make your code more consistent with the domain, and by doing so also improve maintainability.
+Importing side effects directly into your code should be considered bad practice. If you think about it from an application standpoint it is kinda weird that it runs HTTP verb methods with a URL string passed in. It is better to create an abstraction around it to make your code more consistent with the domain, and by doing so also improve maintainability.

--- a/packages/overmind-website/guides/beginner/06_typescript.md
+++ b/packages/overmind-website/guides/beginner/06_typescript.md
@@ -1,12 +1,12 @@
 # Typescript
 
-Overmind is written in Typescript and it is written with a focus on your keeping as little time as possible helping Typescript understand what your app is all about. Typescript will spend a lot more time helping you. If you are not a Typescript developer Overmind is a really great project to start learning it as you will get the most out of the little typing you have to do.
+Overmind is written in Typescript and it is written with a focus on you dedicating as little time as possible to help Typescript understand what your app is all about. Typescript will spend a lot more time helping you. If you are not a Typescript developer Overmind is a really great project to start learning it as you will get the most out of the little typing you have to do.
 
 ## Two typing approaches
 
 ### 1. Declare module
 
-The most straight forward way to type your application is to use the **declare module** approach. This will work for most applications, but might make you feel uncomfortable as a harcore Typescripter. The reason is that we are overriding an internal type, meaning that you can only have one instance of Overmind running inside your application.
+The most straightforward way to type your application is to use the **declare module** approach. This will work for most applications, but might make you feel uncomfortable as a hardcore Typescripter. The reason is that we are overriding an internal type, meaning that you can only have one instance of Overmind running inside your application.
 
 ```marksy
 h(Example, { name: "guide/typescript/declare" })
@@ -34,7 +34,7 @@ h(Example, { name: "guide/typescript/explicit_import" })
 ```
 
 ```marksy
-h(Notice, null, "The Overmind documentation is written for implicit typing. That means whenever you see a type import directly from the Overmind package, you should rather import from your own defined types")
+h(Notice, null, "The Overmind documentation is written for implicit typing. That means whenever you see a type import directly from the Overmind package, you should rather import from your own defined types.")
 ```
 
 ## Linting
@@ -43,13 +43,13 @@ When you are using TSLint it is important that you use the official [Microsoft E
 
 ## Actions
 
-The action type takes either an input type, an output type or both.
+The action type takes either an input type, an output type, or both.
 
 ```marksy
 h(Example, { name: "guide/typescript/action" })
 ```
 
-You also have **async** version of this type. You use this when you want to define an **async** function, which implicitly returns a promise, or a function that explicitly returns a promise.
+You also have an **async** version of this type. You use this when you want to define an **async** function, which implicitly returns a promise, or a function that explicitly returns a promise.
 
 ```marksy
 h(Example, { name: "guide/typescript/async_action" })
@@ -58,13 +58,13 @@ h(Example, { name: "guide/typescript/async_action" })
 
 ## Operators
 
-Operators is like the **Action** type, it can take an optional input, but it always produces an output. By default the output of an operator is the same as the input.
+Operators is like the **Action** type: it can take an optional input, but it always produces an output. By default the output of an operator is the same as the input.
 
 ```marksy
 h(Example, { name: "guide/typescript/operatorinputsandoutputs" })
 ```
 
-The **Operator** type is used to type all operators. The type arguments you give to **Operator** has to match the specific operator you use though. So for example if you type a **mutate** operator with a different output than the input:
+The **Operator** type is used to type all operators. The type arguments you give to **Operator** have to match the specific operator you use though. So for example if you type a **mutate** operator with a different output than the input:
 
 ```marksy
 h(Example, { name: "guide/typescript/wrongoperator" })
@@ -90,7 +90,7 @@ To fix this we just add a generic type to the definition of our operator:
 h(Example, { name: "guide/typescript/operatorinfer_solution" })
 ```
 
-Now Typescript infers the input type of the operator and passes it a long.
+Now Typescript infers the input type of the operator and passes it along.
 
 ### Partial input
 

--- a/packages/overmind-website/guides/beginner/07_structuringtheapp.md
+++ b/packages/overmind-website/guides/beginner/07_structuringtheapp.md
@@ -6,7 +6,7 @@ You will quickly see the need to give more structure to your application. The ba
 
 does not scale very well.
 
-The before mentioned base structure is called **the configuration** of your application and tools are provided to create more complex configurations. But before we look at those tools, lets talk about file structure.
+The abovementioned base structure is called **the configuration** of your application and tools are provided to create more complex configurations. But before we look at those tools, let's talk about file structure.
 
 ## Domains
 
@@ -16,7 +16,7 @@ As your application grows you start to separate it into different domains. A dom
 h(Example, { name: "guide/structuringtheapp/files" })
 ```
 
-In this structure we are splitting up the differet components of the base structure. This is a good first step. The **index** file acts as the file that brings the state, actions and effects together.
+In this structure we are splitting up the different components of the base structure. This is a good first step. The **index** file acts as the file that brings the state, actions and effects together.
 
 But if we want to split up into actual domains it would look more like this:
 
@@ -69,5 +69,5 @@ h(Example, { name: "guide/structuringtheapp/namespaced" })
 We used the **namespaced** function to put the state, actions and effects from each domain behind a key. In this case the key is the same as the name of the domain itself. This is an effective way to split up your app. 
 
 ```marksy
-h(Notice, null, "Even though you split up into different domains each domain has access to the state of the whole application. This is an important feature of Overmind which allows you to scale up and explore the domains of the application without having to worry about isolation")
+h(Notice, null, "Even though you split up into different domains each domain has access to the state of the whole application. This is an important feature of Overmind which allows you to scale up and explore the domains of the application without having to worry about isolation.")
 ```

--- a/packages/overmind-website/guides/beginner/08_connectingcomponents.md
+++ b/packages/overmind-website/guides/beginner/08_connectingcomponents.md
@@ -1,6 +1,6 @@
 # Connecting components
 
-Now that you have state defined, describing your application, you probably want to transform that state into a user interface. There are many ways to express this and Overmind supports the most popular libraries and frameworks for doing this transformation, typically called a view layer. You can also implement a custom view layer if you want to.
+Now that you have defined a state describing your application, you probably want to transform that state into a user interface. There are many ways to express this and Overmind supports the most popular libraries and frameworks for doing this transformation, typically called a view layer. You can also implement a custom view layer if you want to.
 
 By installing the view layer of choice you will be able to connect it to your Overmind instance, exposing its state, actions and effects.
 
@@ -8,17 +8,17 @@ By installing the view layer of choice you will be able to connect it to your Ov
 h(Example, { name: "guide/connectingcomponents/connect" })
 ```
 
-In this example we are accessing the **isLoading** state. When this component renders and this state is accessed, Overmind will automatically understand that this component is interested in this exact state. That means whenever the value is changed this component will render again.
+In this example we are accessing the **isLoading** state. When this component renders and this state is accessed, Overmind will automatically understand that this component is interested in this exact state. It means that whenever the value is changed, this component will render again.
 
 ## State
 
-When Overmind detects that the **App** component is interested in our **isLoading** state, it is not looking at the value itself, it is looking at the path. The component pointed to **state.isLoading**, which means when a mutation occurs on that path in the state, the component will render again. Since the value is a boolean value this can only happen when **isLoading** is replaced or removed. The same goes for strings and numbers as well. We do not say that we mutate a string, boolean or a number. We mutate the object or array that holds those values.
+When Overmind detects that the **App** component is interested in our **isLoading** state, it is not looking at the value itself, it is looking at the path. The component is pointed to **state.isLoading** which means that when a mutation occurs on that path in the state, the component will render again. Since the value is a boolean value this can only happen when **isLoading** is replaced or removed. The same goes for strings and numbers as well. We do not say that we mutate a string, boolean or a number. We mutate the object or array that holds those values.
 
-The story is a bit different if the state value is an object or an array. These values can not only be replaced and removed, they can also mutate themselves. An object can have keys added or removed. An array can have items added, removed and even change order of items. Overmind knows this and will notify components respectively. Let us look at how Overmind treats the following scenarios to get a better understanding.
+The story is a bit different if the state value is an object or an array. These values can not only be replaced and removed, they can also mutate themselves. An object can have keys added or removed. An array can have items added, removed and even change the order of items. Overmind knows this and will notify components respectively. Let us look at how Overmind treats the following scenarios to get a better understanding.
 
 ### Arrays
 
-When we just access an array in a component it will rerender if the array itself is replaced, removed or we do a mutation to it. That would mean we push a new item to it, we splice it or sort it.
+When we just access an array in a component it will re-render if the array itself is replaced, removed or we do a mutation to it. That would mean we push a new item to it, we splice it or sort it.
 
 ```marksy
 h(Example, { name: "guide/connectingcomponents/array_1" })
@@ -36,12 +36,12 @@ Now Overmind also sees that this component is interested in the id and title of 
 h(Example, { name: "guide/connectingcomponents/array_3" })
 ```
 
-The benefit now is that the **List** component will only render when there is a change to the actual list. While each individual **Item** component will render when its respective title changes.
+The benefit now is that the **List** component will only render when there is a change to the actual list, while each individual **Item** component will render when its respective title changes.
 
 
 ### Objects
 
-Objects are similar to arrays. If you access an object you track if that object is replaced or removed. Also like arrays you can mutate the object itself. When you add, replace or remove a key from the object that is considered a mutation of the object. That means if you just access the object, the component will render if any keys are added, replaced or removed.
+Objects are similar to arrays. If you access an object you track if that object is replaced or removed. As with arrays, you can mutate the object itself. When you add, replace or remove a key from the object, it is considered a mutation of the object. It means that if you just access the object, the component will render if any keys are added, replaced or removed.
 
 ```marksy
 h(Example, { name: "guide/connectingcomponents/object_1" })
@@ -55,19 +55,19 @@ h(Example, { name: "guide/connectingcomponents/object_2" })
 
 ## Actions
 
-All the actions defined in the Overmind application is available to connected components.
+All the actions defined in the Overmind application are available to connected components.
 
 ```marksy
 h(Example, { name: "guide/connectingcomponents/actions" })
 ```
 
 ```marksy
-h(Notice, null, "If you need to pass multiple values to an action, you rather use an **object** instead")
+h(Notice, null, "If you need to pass multiple values to an action, you should rather use an **object** instead.")
 ```
 
 ## Reactions
 
-Sometimes you want to make something happen inside a component related to a state change. This is typically doing some manual work on the DOM. When you connect a component to overmind it also gets access to **addMutationListener**. This function allows you to subscribe to changes in state, mutations as we call them. Each mutation holds information about what kind of mutation it was, at what path it happened and even any arguments used in the mutation. You can use all this information to create an effect.
+Sometimes you want to make something happen inside a component related to a state change. This is typically doing some manual work on the DOM. When you connect a component to Overmind it also gets access to **addMutationListener**. This function allows you to subscribe to changes in state, mutations as we call them. Each mutation holds information about what kind of mutation it was, at what path it happened and even any arguments used in the mutation. You can use all this information to create an effect.
 
 This example shows how you can scroll to the top of the page every time you change the current article of the app.
 
@@ -77,4 +77,4 @@ h(Example, { name: "guide/connectingcomponents/effects" })
 
 ## Effects
 
-Any effects you define in your Overmind application is also exposed to the components. They can be found on the property **effects**. It is encouraged that you keep your logic inside actions, but you might be in a situation where you want some other relationship between components and Overmind. A shared effect is the way to go.
+Any effects you define in your Overmind application are also exposed to the components. They can be found on the property **effects**. It is encouraged that you keep your logic inside actions, but you might be in a situation where you want some other relationship between components and Overmind. A shared effect is the way to go.

--- a/packages/overmind-website/guides/beginner/09_usingovermindwithreact.md
+++ b/packages/overmind-website/guides/beginner/09_usingovermindwithreact.md
@@ -2,7 +2,7 @@
 
 There are two different ways to connect Overmind to React. You can either use a traditional **Higher Order Component** or you can use the new **hooks** api to expose state and actions.
 
-When you connect Overmind to a component you ensure that whenever any tracked state changes only components interested in that state will rerender and they will rerender "at their point in the component tree". That means we remove a lot of unnecessary work from React. There is no reason for the whole React component tree to rerender when only one component is interested in a change.
+When you connect Overmind to a component you ensure that whenever any tracked state changes, only components interested in that state will re-render, and will do so "at their location in the component tree". That means we remove a lot of unnecessary work from React. There is no reason for the whole React component tree to re-render when only one component is interested in a change.
 
 ## With hook
 ```marksy
@@ -30,7 +30,7 @@ The hook effect of React gives a natural point of running effects related to sta
 h(Example, { name: "guide/usingovermindwithreact/hook_effect" })
 ```
 
-You can also here use the traditional approach adding a subscription to any updates. This also allows for more granular control as you can check the specific mutations made and/or do pattern matching on the paths updated.
+Here you can also use the traditional approach of subscribing to updates. This also allows for more granular control as you can check the specific mutations made and/or do pattern matching on the paths updated.
 
 ```marksy
 h(Example, { name: "guide/usingovermindwithreact/hook_effect_subscription" })

--- a/packages/overmind-website/guides/beginner/10_usingovermindwithangular.md
+++ b/packages/overmind-website/guides/beginner/10_usingovermindwithangular.md
@@ -27,7 +27,7 @@ When you connect Overmind to your component and expose state you do not have to 
 
 ## Passing state as input
 
-When you pass state objects or arrays as input to a child component that state will by default be tracked on the component passing it a long, which you can also see in the devtools. By just adding the **\*tracker** directive to the child template and the tracking will be handed over:
+When you pass state objects or arrays as input to a child component that state will by default be tracked on the component passing it along, which you can also see in the devtools. By just adding the **\*tracker** directive to the child template, the tracking will be handed over:
 
 ```marksy
 h(Example, { name: "guide/usingovermindwithangular/passprop" })

--- a/packages/overmind-website/guides/beginner/11_usingovermindwithvue.md
+++ b/packages/overmind-website/guides/beginner/11_usingovermindwithvue.md
@@ -3,7 +3,7 @@
 There are two approaches to connecting Overmind to Vue.
 
 ```marksy
-h(Notice, null, "Please use Vue version **2.6** or later")
+h(Notice, null, "Please use Vue version **2.6** or later".)
 ```
 
 ## Plugin
@@ -21,7 +21,7 @@ h(Example, { name: "guide/usingovermindwithvue/connect_plugin_config" })
 ```
 
 ### Rendering
-Any state accessed in the component will cause the component to render when a mutation occurs on that state. Overmind actually uses the same approach to change detection as Vue itself. When using the plugin any component can access any state, though the only overhead that is added to the application is an instance of a "tracking tree" per component. This might sound scary, but it is a tiny little object that adds a callback function to Overmind as long as the component lives.These tracking trees are even reused as components unmount.
+Any state accessed in the component will cause the component to render when a mutation occurs on that state. Overmind actually uses the same approach to change detection as Vue itself. When using the plugin any component can access any state, though the only overhead that is added to the application is an instance of a "tracking tree" per component. This might sound scary, but it is a tiny little object that adds a callback function to Overmind as long as the component lives. These tracking trees are even reused as components unmount.
 
 ### Pass state as props
 
@@ -41,7 +41,7 @@ h(Example, { name: "guide/usingovermindwithvue/effect" })
 
 ## Connect
 
-If you want more manual control of what components connect to Overmind you can rather use the connector.
+If you want more manual control of what components connect to Overmind you can use the connector.
 
 ```marksy
 h(Example, { name: "guide/usingovermindwithvue/connect" })
@@ -55,25 +55,6 @@ h(Example, { name: "guide/usingovermindwithvue/connect_custom" })
 
 You can now access the **admin** state and actions directly with **state** and **actions**.
 
-
-### Rendering
-Any state accessed in the component will cause the component to render when a mutation occurs on that state. Overmind actually uses the same approach to change detection as Vue itself.
-
-### Pass state as props
-
-If you pass a state object or array as a property to a child component you will also in the child component need to **connect**. This ensures that the property you passed is tracked within that component, even though you do not access any state or actions from Overmind. The devtools will help you identify where any components are left "unconnected".
-
-```marksy
-h(Example, { name: "guide/usingovermindwithvue/passprops" })
-```
-
-### State effects
-
-To run effects in components based on changes to state you use the **addMutationListener** function in the lifecycle hooks of Vue.
-
-```marksy
-h(Example, { name: "guide/usingovermindwithvue/effect" })
-```
 
 ## Computed
 

--- a/packages/overmind-website/guides/intermediate/01_managinglists.md
+++ b/packages/overmind-website/guides/intermediate/01_managinglists.md
@@ -1,6 +1,6 @@
 # Managing lists
 
-Why do we even have a guide to manage lists? Well, lists is a type of state that differs from other state. Both from the perspective of the state itself, but also transforming that state into UI.
+Why do we even have a guide to managing lists? Well, lists are a type of state that differ from other types of state. Both from the perspective of the state itself, but also transforming that state into UI.
 
 ```marksy
 h(Notice, null, "The discussion of lists is not specific to Overmind and there are no limitations on how you want to approach this. This guide is rather to help you think about how you structure entities (data with an id) to optimally access and render them.")
@@ -9,13 +9,13 @@ h(Notice, null, "The discussion of lists is not specific to Overmind and there a
 ## Defining the state
 When we want to render a list of something we want an **array**. This is the data structure we instinctively go to as it basically is a list. But arrays are rarely the way you want to store the actual data of the list. 
 
-If your list consists of posts, these posts are most likely entities from the server which are unique, they have a unique id. A data structure the better manages uniqueness is an **object**.
+If your list consists of posts, these posts are most likely entities from the server which are unique, and have a unique id. A data structure that better manages uniqueness is an **object**.
 
 ```marksy
 h(Example, { name: "guide/managinglists/object" })
 ```
 
-Another benefit from using an object is that you have a direct reference to the entity by using its id. No need to iterate an array to find what you are looking for. So this is a good rule of thumb. If the state you are defining has unique identifiers they should most likely be stored as an object, not an array.
+Another benefit from using an object is that you have a direct reference to the entity by using its id. No need to iterate an array to find what you are looking for. So this is a good rule of thumb: if the state you are defining has unique identifiers they should most likely be stored as an object, not an array.
 
 But we still want to use an array when we transform the state into a UI. Let us see what we can do about that.
 
@@ -26,44 +26,44 @@ In Overmind it is encouraged that you derive these dictionaries of entities to a
 h(Example, { name: "guide/managinglists/derivetolist" })
 ```
 
-Now when we point to **state.postsList** we get an array of posts. What is important to remember here is that we do not create the list again whenever we point to this state value. It is only run again if there is a change to the depending posts state.
+Now when we point to **state.postsList** we get an array of posts. What is important to remember here is that we do not create the list again whenever we point to this state value. It is only run again if there is a change to the referenced posts' state.
 
 ## Sorting
 
-Now we have optimally stored our posts in a dictionary for easy access by id. We have also created a derived state which converts this dictionary to an array whenever the source dictionary changes. Though most likely you want to sort the list. Typically lists are sorted chronologically and our posts has a **datetime** field.
+Now we have optimally stored our posts in a dictionary for easy access by id. We have also created a derived state which converts this dictionary to an array whenever the source dictionary changes. Though most likely you want to sort the list. Typically lists are sorted chronologically and our posts item has a **datetime** field.
 
 ```marksy
 h(Example, { name: "guide/managinglists/sort" })
 ```
 
-There we go, our posts are now shown chronologically. But maybe we we only want to show some of the posts that are available? Maybe the list should only contain the ten latest?
+There we go, our posts are now shown chronologically. But maybe we only want to show some of the posts that are available? Maybe the list should only contain the ten latest entries?
 
 ## Filtering
 
-To limit the number of posts shown we can create a new state and use it inside our derived to limit the number of results.
+To limit the number of posts shown we can create a new state and use it inside our derived state to limit the number of results.
 
 ```marksy
 h(Example, { name: "guide/managinglists/filtering" })
 ```
 
-Now if we change the **showCount** state indeed our derived list will update.
+Now if we change the **showCount** state our derived list will indeed update.
 
 ## Rendering lists
 
-So now lets look at how we would consume such a list. Let us look at a straight forward example first:
+So now let's look at how we would consume such a list. Let us look at a straightforward example first:
 
 ```marksy
 h(Example, { name: "guide/managinglists/render" })
 ```
 
-Now this approach will work perfectly fine. The component will render the list and update it whenever it needs to. The only drawback with this approach is that any change to individual posts will also cause the component to render, specifically the **title** of a post since that is the only thing we are looking at. This is because this one component is looking at all the posts. We can optimize this by rather passing each post down to a child component:
+Now this approach will work perfectly fine. The component will render the list and update it whenever it needs to. The only drawback with this approach is that any change to individual posts will also cause the component to render, specifically the **title** of a post since that is the only thing we are looking at. This is because this one component is looking at all the posts. We can optimize this by passing each post down to a child component:
 
 ```marksy
 h(Example, { name: "guide/managinglists/render2" })
 ```
 
-Now the **Posts** component only cares about changes to the list itself, while each **Post** component cares about its correspoding post title. That means if the title of a post updates only the component that actually cares about that post renders again. If the list itself changes only the **Posts** component will render.
+Now the **Posts** component only cares about changes to the list itself, while each **Post** component cares about its corresponding post title. It means that if the title of a post updates, only the component that actually cares about that post renders again. If the list itself changes only the **Posts** component will render.
 
 ## Summary
 
-Managing lists has two parts. Defining how to store the data of the list and how to actually render the list. It can be a good idea to store data entities with unique ids as a dictionary and rather use a **derived** state to produce the array itself. This gives you best of both worlds. Easy lookup using the id and a cached list that only updates when dependent state updates.
+Managing lists has two considerations: defining how to store the data of the list, and how to actually render the list. It can be a good idea to store data entities with unique ids as a dictionary and rather use a **derived** state to produce the array itself. This gives you best of both worlds – easy lookup using the id, and a cached list that only updates when dependent state updates.

--- a/packages/overmind-website/guides/intermediate/02_routing.md
+++ b/packages/overmind-website/guides/intermediate/02_routing.md
@@ -2,9 +2,9 @@
 
 With Overmind you can use whatever routing solution your selected view layer provides. This will most likely intertwine routing state with your component state, which is something Overmind would discourage, but you know... whatever you feel productive in, you should use :-) In this guide we will look into how you can separate your router from your components and make it part of your application state instead. This is more in the spirit of Overmind and throughout this guide you will find benefits of doing it this way.
 
-We are going to use [page js](https://www.npmjs.com/package/page) as the router and we will look at a complex routing example where we open a page with a link to a list of users. When you click a user in the list we will show that user in a modal with the url updating to the id of the user. In addition we will present a query parameter that reflects the current tab inside the modal.
+We are going to use [page.js](https://www.npmjs.com/package/page) as the router and we will look at a complex routing example where we open a page with a link to a list of users. When you click on a user in the list we will show that user in a modal with the URL updating to the id of the user. In addition we will present a query parameter that reflects the current tab inside the modal.
 
-We will start with a simple naive approach and then we are going to tweak our approach a little bit for the optimal solution.
+We will start with a simple naïve approach and then tweak our approach a little bit for the optimal solution.
 
 ## Set up the app
 
@@ -12,7 +12,7 @@ Before we go into the router we want to set up the application. We have some sta
 
 1. **showHomePage** tells our application to set the current page to *home*
 2. **showUsersPage** tells our application to set the current page to *users* and fetches the users as well
-3. **showUserModal** tells our application to show the modal by setting an id of a user passed to the action. This action will also handle the switching of tabs later
+3. **showUserModal** tells our application to show the modal by setting an id of a user passed to the action. This action will also handle the switching of tabs later.
 
 
 ```marksy
@@ -21,13 +21,13 @@ h(Example, { name: "guide/routing/setup" })
 
 ## Initialize the router
 
-**Page js** is pretty straight forward. We basically want to map a url to trigger an action. To get started let us first add Page js as an effect and let us take the opportunity to create a custom API. When a url triggers we want to pass the params of the route to the action linked to the route:
+**Page.js** is pretty straightforward. We basically want to map a URL to trigger an action. To get started, let us first add Page.js as an effect and take the opportunity to create a custom API. When a URL triggers we want to pass the params of the route to the action linked to the route:
 
 ```marksy
 h(Example, { name: "guide/routing/effect" })
 ```
 
-Now we can use Overminds **onInitialize** to configure the router. That way the initial url triggers before the UI renders and we get to set our initial state.
+Now we can use Overmind's **onInitialize** to configure the router. That way the initial URL triggers before the UI renders and we get to set our initial state.
 
 ```marksy
 h(Example, { name: "guide/routing/pagejs" })
@@ -37,7 +37,7 @@ Take notice here that we are actually passing in the params from the router, mea
 
 ## The list of users
 
-When we now go to the list of users the list loads up and is displayed. When we click a user the url changes, our **showUser** action runs and indeed, we see a user modal.
+When we now go to the list of users the list loads up and is displayed. When we click on a user the URL changes, our **showUser** action runs and indeed, we see a user modal.
 
 
 ```marksy
@@ -45,11 +45,11 @@ h(Example, { name: "guide/routing/users" })
 ```
 
 
-But what if we try to refresh now... we get an error. The router tries to run our user modal, but we are on the frontpage. The modal does not exist there. We want to make sure that when we open a link to a user modal we also go to the actual user list page.
+But what if we try to refresh now... we get an error. The router tries to run our user modal, but we are on the front page. The modal does not exist there. We want to make sure that when we open a link to a user modal we also go to the actual user list page.
 
 ## Composing actions
 
-A straight forward way to solve this is to simply also change the page in the **showUserModal** action, though we would like the list of users to load in the background as well. The logic of **showUsers** might also be a lot more complex and we do not want to duplicate our code. When these scenarios occur, where you want to start calling actions from actions, it indicates you have reached a level of complexity where a functional approach might be better. Let us look at how you would implement this both using a functional approach and a plain imperative one.
+A straightforward way to solve this is to simply also change the page in the **showUserModal** action, though we would like the list of users to load in the background as well. The logic of **showUsers** might also be a lot more complex and we do not want to duplicate our code. When these scenarios occur where you want to start calling actions from actions, it indicates you have reached a level of complexity where a functional approach might be better. Let us look at how you would implement this both using a functional approach and a plain imperative one.
 
 ### Imperative approach
 ```marksy
@@ -65,9 +65,9 @@ When running actions from within other actions like this it will be reflected in
 h(Example, { name: "guide/routing/compose" })
 ```
 
-By splitting up all our logic into operators we were able to make our actions completely declarative and at the same time reuse logic across them. The *operators* file gives us maintaineable code and the *actions* file gives us readable code.
+By splitting up all our logic into operators we were able to make our actions completely declarative and at the same time reuse logic across them. The *operators* file gives us maintainable code and the *actions* file gives us readable code.
 
-We could actually make this better though. There is no reason to wait for the user of the modal to load before we load the users list in the background. We can fix this with the **parallel** operator. Now the list of users and the single user loads at the same time.
+We could actually make this better though. There is no reason to wait for the user of the modal to load before we load the users list in the background. We can fix this with the **parallel** operator. Now the list of users and the single user load at the same time.
 
 ```marksy
 h(Example, { name: "guide/routing/parallel" })
@@ -77,7 +77,7 @@ Now you are starting to see how the operators can be quite useful to compose flo
 
 ## The tab query param
 
-**Page js** also allows us to manage query strings, the stuff after the **?** in the url. Page js does not parse it though, so we introduce a library which does just that, [query-string](https://www.npmjs.com/package/query-string). With this we can update our router to also pass in any query params.
+**Page.js** also allows us to manage query strings, the stuff after the **?** in the url. Page.js does not parse it though, so we introduce a library which does just that, [query-string](https://www.npmjs.com/package/query-string). With this we can update our router to also pass in any query params.
 
 
 ```marksy
@@ -85,13 +85,13 @@ h(Example, { name: "guide/routing/query" })
 ```
 
 ### Imperative approach
-We now also handle the received tab param and make sure that when we change tabs we do not load the user again. We only want to load the user when there is no existing user or if the user has changed.
+We now also handle the received tab parameter and make sure that when we change tabs we do not load the user again. We only want to load the user when there is no existing user or if the user has changed.
 
 ```marksy
 h(Example, { name: "guide/routing/tab_imperative" })
 ```
 
-### Functionl approach
+### Functional approach
 Now we can add an operator which uses this **tab** query to set the current tab and then compose it into the action. We also add an operator to verify if we really should load a new user.
 
 ```marksy
@@ -100,6 +100,6 @@ h(Example, { name: "guide/routing/tab" })
 
 ## Summary
 
-With little effort we were able to build a custom "**application state first**" router for our application. Like many common tools needed in an application, like talking to the server, local storage etc., there are often small differences in the requirements. And even more often you do not need the full implementation of the tool you are using. By using simple tools you can meet the actual requirements of the application more "head on" and this was an example of that.
+With little effort we were able to build a custom "**application state first**" router for our application. Like many common tools needed in an application, like talking to the server, localStorage etc., there are often small differences in the requirements. And even more often you do not need the full implementation of the tool you are using. By using simple tools you can meet the actual requirements of the application more "head on" and this was an example of that.
 
-We also showed off how you can solve this issue with an imperative approach or go functional. In this example functional is probably a bit overkill as there is very little composition required. But if your application needed to use these operators many times in different configurations you would benefit more from it.
+We also showed how you can solve this issue with an imperative approach or go functional. In this example functional is probably a bit overkill as there is very little composition required. But if your application needed to use these operators many times in different configurations you would benefit more from it.

--- a/packages/overmind-website/guides/intermediate/04_goingfunctional.md
+++ b/packages/overmind-website/guides/intermediate/04_goingfunctional.md
@@ -1,6 +1,6 @@
 # Going functional
 
-You get very far building your application with straight forward imperative actions. This is typically how we learn programming and is arguably close to how we think about the world. But this approach can cause you to overload your actions with imperative code, making them more difficult to read and especially reuse pieces of logic. As the complexity of your application increases you will find benefits doing some of your logic, or maybe all your logic, in a functional style.
+You get very far building your application with straightforward imperative actions. This is typically how we learn programming and is arguably close to how we think about the world. But this approach can cause you to overload your actions with imperative code, making them more difficult to read and especially reuse pieces of logic. As the complexity of your application increases you will find benefits to doing some of your logic, or maybe all your logic, in a functional style.
 
 Let us look at a concrete example of how messy an imperative approach would be compared to a functional approach.
 
@@ -8,7 +8,7 @@ Let us look at a concrete example of how messy an imperative approach would be c
 h(Example, { name: "guide/goingfunctional/messy" })
 ```
 
-What we see here is an action trying to express a search. We only want to search when the length of the query is more than 2 and we only want to trigger the search when the user has not changed the query for 200 milliseconds.
+What we see here is an action trying to express a search. We only want to search when the length of the query is more than 2 characters and we only want to trigger the search when the user has not changed the query for 200 milliseconds.
 
 If we were to do this in a functional style it would look more like this:
 
@@ -37,8 +37,8 @@ h(Notice, null, "Note that we give all the actual operator functions the same na
 
 You might wonder why we define the operators as functions that we call. We do that for the following reasons:
 
-1. It ensures that each composition using the operator has a unique instance of that operator. For most operators this does not matter, but for others like **debounce** it actually matters
-2. Some operators requires options, like the **lengthGreaterThan** operator we created above. Defining all operators as functions just makes things more consistent
+1. It ensures that each composition using the operator has a unique instance of that operator. For most operators this does not matter, but for others like **debounce** it actually matters.
+2. Some operators require options, like the **lengthGreaterThan** operator we created above. Defining all operators as functions just makes things more consistent.
 3. If you were to create an operator that is composed of other operators you can safely do so without thinking about the order of definition in the *operators* file. The reason being that the operator is lazily created
 
 ```marksy

--- a/packages/overmind-website/guides/intermediate/05_writingtests.md
+++ b/packages/overmind-website/guides/intermediate/05_writingtests.md
@@ -1,6 +1,8 @@
 # Writing tests
 
-Testing is a broad subject and everybody has an opinion on it. We can only show you how we think about testing in general and how to effectively write those tests for your Overmind app. It is encouraged to think **unit testing** of actions and effects. This will cover expected changes in state and that your side effects behaves in a predictable manner. If you want to test how your application works when it is all put together we recommend doing integration tests as close to the user experience as possible. Testing solutions like [Cypress.io](https://www.cypress.io/) is a great way to do exactly that. You can read more about Cypress and integration testing with Overmind in [this article](https://www.cypress.io/blog/2019/02/28/shrink-the-untestable-code-with-app-actions-and-effects/#).
+Testing is a broad subject and everybody has an opinion on it. We can only show you how we think about testing in general and how to effectively write those tests for your Overmind app. It is encouraged to think **unit testing** of actions and effects. This will cover expected changes in state and that your side effects behave in a predictable manner.
+
+If you want to test how your application works when it is all put together we recommend doing integration tests as close to the user experience as possible. Testing solutions like [Cypress.io](https://www.cypress.io/) are a great way to do exactly that. You can read more about Cypress and integration testing with Overmind in [this article](https://www.cypress.io/blog/2019/02/28/shrink-the-untestable-code-with-app-actions-and-effects/#).
 
 ## Structuring the app
 
@@ -14,7 +16,7 @@ Now we are free to import our configuration without touching the application ins
 
 ## Testing actions
 
-When testing an action you want to verify that changes to state are performed as expected. To give you the best possible testing experience Overmind has mocking tool called **createOvermindMock**. It takes your application configuration and allows you to run actions as if they were run from components.
+When testing an action you'll want to verify that changes to state are performed as expected. To give you the best possible testing experience Overmind comes with a mocking tool called **createOvermindMock**. It takes your application configuration and allows you to run actions as if they were run from components.
 
 ```marksy
 h(Example, { name: "guide/writingtests/action.ts" })
@@ -26,7 +28,7 @@ You might want to test if a thrown error is handled correctly here. This is an e
 h(Example, { name: "guide/writingtests/actiontest.ts" })
 ```
 
-If your actions can result in multiple scenarios a unit test is beneficial. But you will be surprised how straight forward the logic of your actions will become. Since effects are encouraged to be application specific you will most likely be testing those more than you will test any action.
+If your actions can result in multiple scenarios a unit test is beneficial. But you will be surprised how straightforward the logic of your actions will become. Since effects are encouraged to be application specific you will most likely be testing those more than you will test any action.
 
 You do not have to explicitly write the expected state. You can also use for example [jest]() for snapshot testing. The mock instance has a list of mutations performed. This is perfect for snapshot testing.
 
@@ -47,9 +49,9 @@ h(Example, { name: "guide/writingtests/oninitializetest.ts" })
 
 ## Testing effects
 
-Where you want to put in your effort is with the effects. This is where you have your chance to build a domain specific API for your actual application logic. The bridge between some generic tool and what your application actually wants to use it for.
+Where you want to put in your effort is with the effects. This is where you have your chance to build a domain specific API for your actual application logic. This is the bridge between some generic tool and what your application actually wants to use it for.
 
-A simple example of this is doing requests. Maybe you want to use axios to reach your API, but you do not really care about testing that library. What you want to test is that it is used correctly when you use your application specific API.
+A simple example of this is doing requests. Maybe you want to use e.g. [axios](https://github.com/axios/axios) to reach your API, but you do not really care about testing that library. What you want to test is that it is used correctly when you use your application specific API.
 
 This is just an example showing you how you can structure your code for optimal testability. You might prefer a different approach or maybe rely on integration tests for this. No worries, you do what makes most sense for your application:
 
@@ -57,10 +59,10 @@ This is just an example showing you how you can structure your code for optimal 
 h(Example, { name: "guide/writingtests/effect.ts" })
 ```
 
-Lets see how you could write a test for it:
+Let's see how you could write a test for it:
 
 ```marksy
 h(Example, { name: "guide/writingtests/effecttest.ts" })
 ```
 
-Again, effects is where you typically have your most brittle logic. With the approach just explained you will have a good separation between your application logic and the brittle and "impure". In an Overmind app, especially written in Typescript, you get very far just testing your effects and then do integration tests for your application. But as mentioned in the introduction we all have very different opinions on this, at least the API allows testing to whatever degree you see fit.
+Again, effects are where you typically have your most brittle logic. With the approach just explained you will have a good separation between your application logic and the brittle and "impure". In an Overmind app, especially written in Typescript, you get very far just testing your effects and then do integration tests for your application. But as mentioned in the introduction we all have very different opinions on this, at least the API allows testing to whatever degree you see fit.

--- a/packages/overmind-website/guides/pro/01_serversiderendering.md
+++ b/packages/overmind-website/guides/pro/01_serversiderendering.md
@@ -1,10 +1,10 @@
 # Server Side Rendering
 
-Some projects requires you to render your application on the server. There are different reason to do this, like search engine optimizations, general optimizations and even browser support. What this means for state management is that you want to expose a version of your state on the server and render the components with that state. But that is not all, you also want to **hydrate** the changed state and pass it to the client with the HTML so that it can **rehydrate** and make sure that when the client renders initially, it renders the same UI.
+Some projects require you to render your application on the server. There are different reasons to do this, like search engine optimizations, general optimizations and even browser support. What this means for state management is that you want to expose a version of your state on the server and render the components with that state. But that is not all, you also want to **hydrate** the changed state and pass it to the client with the HTML so that it can **rehydrate** and make sure that when the client renders initially, it renders the same UI.
 
 ## Preparing the project
 
-When doing server side rendering the configuration of your application will be shared by the client and the server. That means you need to structure your app to make that possible. There is really not much you need to do.
+When doing server-side rendering the configuration of your application will be shared by the client and the server. That means you need to structure your app to make that possible. There is really not much you need to do.
 
 ```marksy
 h(Example, { name: "guide/writingtests/structuringtheapp.ts" })
@@ -14,11 +14,11 @@ Here we only export the configuration from the main Overmind file. The instantia
 
 ## Preparing effects
 
-The effects will also be shared with the server. Typically this is not an issue, but you should be careful about creating effects that runs logic when they are defined. You might also consider lazy loading effects so that you avoid loading them on the server at all. You can read more about in the [running side effects guide](/http://localhost:4000/guides/beginner/04_runningsideeffects).
+The effects will also be shared with the server. Typically this is not an issue, but you should be careful about creating effects that run logic when they are defined. You might also consider lazy-loading effects so that you avoid loading them on the server at all. You can read more about them in the [running side effects guide](/http://localhost:4000/guides/beginner/04_runningsideeffects).
 
 ## Rendering on the server
 
-When you render your application on the server you will have to create an instance of Overmind designed for running on the server. On this instance you can change the state and provide it to your components for rendering. When the components have rendered you can **hydrate** the changes and pass them a long to the client so that you can **rehydrate**.
+When you render your application on the server you will have to create an instance of Overmind designed for running on the server. On this instance you can change the state and provide it to your components for rendering. When the components have rendered you can **hydrate** the changes and pass them along to the client so that you can **rehydrate**.
 
 ```marksy
 h(Notice, null, "Overmind does not hydrate the state, but the mutations you performed. That means it minimizes the payload passed over the wire.")
@@ -39,5 +39,5 @@ h(Example, { name: "guide/serversiderendering/renderonclient.ts" })
 ```
 
 ```marksy
-h(Notice, null, "If you are using state first routing, make sure you prevent the router from firing off the initial route, as this is not needed")
+h(Notice, null, "If you are using state first routing, make sure you prevent the router from firing off the initial route, as this is not needed.")
 ```

--- a/packages/overmind-website/guides/pro/02_createcustomoperators.md
+++ b/packages/overmind-website/guides/pro/02_createcustomoperators.md
@@ -1,6 +1,6 @@
 # Create custom operators
 
-The operators of Overmind is based on the [op-op spec](https://github.com/christianalfoni/op-op-spec), which allows for endless possibilities in functional composition. But since Overmind does not only pass values through these operators, but also the context where you can change state, run effects etc., we want to simplify how you can create your own operators. The added benefit of this is that the operators you create are also tracked in the devtools.
+The operators concept of Overmind is based on the [op-op spec](https://github.com/christianalfoni/op-op-spec), which allows for endless possibilities in functional composition. But since Overmind does not only pass values through these operators, but also the context where you can change state, run effects etc., we want to simplify how you can create your own operators. The added benefit of this is that the operators you create are also tracked in the devtools.
 
 ## toUpperCase
 
@@ -10,13 +10,13 @@ Let us create an operator that simply uppercases the string value passed through
 h(Example, { name: "guide/createcustomoperators/touppercase" })
 ```
 
-We first create a function that returns an operator when we call it. We pass this operator a **name**, an optional **description** and the callback that is executed when the operator runs. This operator might receive an **error**, that you can handle if you want to. It also receives the **context**, the current **value** and function called **next**.
+We first create a function that returns an operator when we call it. We pass this operator a **name**, an optional **description** and the callback that is executed when the operator runs. This operator might receive an **error**, that you can handle if you want to. It also receives the **context**, the current **value** and a function called **next**.
 
-In this example we did not use the **context** because we are not going to look at any state, run effects etc. We just wanted to change the value passed through. All operators needs to handle the **error** in some way. In this case we just pass it a long to the next operator by calling **next** with the error as the first argument and the current value as the second. When there is no error it means we can manage our value and we do so by calling **next** again, but passing **null** as the first argument, as there is no error. And the second argument is the new **value**.
+In this example we did not use the **context** because we are not going to look at any state, run effects etc. We just wanted to change the value passed through. All operators need to handle the **error** in some way. In this case we just pass it along to the next operator by calling **next** with the error as the first argument and the current value as the second. When there is no error it means we can manage our value and we do so by calling **next** again, but passing **null** as the first argument, as there is no error. And the second argument is the new **value**.
 
 ## operations
 
-You might want to run some logic related to your operator. Typically this is done by giving a callback. You can provide this callback whatever information you want, even handle its return value. So for example the **map** operator is implemented likt his:
+You might want to run some logic related to your operator. Typically this is done by giving a callback. You can provide this callback whatever information you want, even handle its return value. So for example the **map** operator is implemented like this:
 
 ```marksy
 h(Example, { name: "guide/createcustomoperators/map" })
@@ -24,7 +24,7 @@ h(Example, { name: "guide/createcustomoperators/map" })
 
 ## mutations
 
-You can also create operators that has the ability to mutate the state, it is just a different factory **createMutationFactory**. This is how the **action** operator is implemented:
+You can also create operators that have the ability to mutate the state, it is just a different factory **createMutationFactory**. This is how the **action** operator is implemented:
 
 ```marksy
 h(Example, { name: "guide/createcustomoperators/action" })
@@ -40,7 +40,7 @@ h(Example, { name: "guide/createcustomoperators/when" })
 
 ## aborting
 
-Some operators wants to prevent further execution. That is also possible to implement, as seen here with the **filter** operator:
+Some operators want to prevent further execution. That is also possible to implement, as seen here with the **filter** operator:
 
 ```marksy
 h(Example, { name: "guide/createcustomoperators/filter" })


### PR DESCRIPTION
As I read through the Overmind guide, I thought I'd make little spelling corrections and tweak the text for a bit more fluency as I go. These are really mostly simple corrections and occasional rewordings. :)

- In the Vue section I specifically noticed there were some duplicated paragraphs, so it's probably a good idea to double-check I didn't mess up anything.
- I noticed `overmind-website/examples/guide/serversiderendering/renderonserver.ts` didn't get rendered in the SSR guide, wonder if there's a syntax error? Didn't examine deeper in this PR, though.