### PR TITLE
feat(overmind): add throttle operator

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -1443,3 +1443,29 @@ export function debounce<Input, ThisConfig extends IConfiguration = Config>(
     }
   )
 }
+
+export function throttle<Input, ThisConfig extends IConfiguration = Config>(
+  ms: number
+): IOperator<ThisConfig, Input, Input> {
+  let timeout
+  let previousFinal
+
+  return createOperator(
+    'throttle',
+    String(ms),
+    (err, context, value, next, final) => {
+      if (err) next(err, value)
+      else {
+        if (timeout) {
+          previousFinal(null, value)
+        } else {
+          timeout = setTimeout(() => {
+            timeout = null
+            next(null, value)
+          }, ms)
+        }
+        previousFinal = final
+      }
+    }
+  )
+}

--- a/packages/node_modules/overmind/src/operators.test.ts
+++ b/packages/node_modules/overmind/src/operators.test.ts
@@ -15,6 +15,7 @@ import {
   IAction,
   catchError,
   tryCatch,
+  throttle,
 } from './'
 
 describe('OPERATORS', () => {
@@ -316,6 +317,35 @@ describe('OPERATORS', () => {
       }
     )
   })
+  test('throttle', () => {
+    expect.assertions(1)
+    const test: Operator = pipe(
+      throttle(100),
+      mutate(({ state }) => state.runCount++)
+    )
+    const state = {
+      runCount: 0,
+    }
+    const config = {
+      state,
+      actions: {
+        test,
+      },
+    }
+    const overmind = new Overmind(config)
+
+    type Config = IConfig<typeof config>
+
+    interface Operator<Input = void, Output = Input>
+      extends IOperator<Config, Input, Output> {}
+
+    return Promise.all([overmind.actions.test(), overmind.actions.test()]).then(
+      () => {
+        expect(overmind.state.runCount).toBe(1)
+      }
+    )
+  })
+
   test('catchError', () => {
     expect.assertions(3)
     const test: Operator<string> = pipe(


### PR DESCRIPTION
Difference between the **throttle** and **debounce** operators:

The **throttle** operator executes the "next" path at most every x [ms].

The **debounce** operator executes the "next" path x [ms] after the last call.

If there is a very long delay (say 30 seconds), and calls keep coming every few seconds, **debounce** would never execute the next statements whereas **throttle** would execute every 30 seconds.

@christianalfoni Please review the code as it is based on debounce and I am not sure about the "next" call inside the timeout or what the "final" thing is.