### PR TITLE
State tree improvements

### DIFF
--- a/packages/node_modules/proxy-state-tree/package.json
+++ b/packages/node_modules/proxy-state-tree/package.json
@@ -1,40 +1,53 @@
 {
-	"name": "proxy-state-tree",
-	"version": "1.0.0-beta4",
-	"description": "An implementation of the Mobx/Vue state tracking approach, for library authors",
-	"main": "lib/index.js",
-	"module": "es/index.js",
-	"types": "lib/index.d.ts",
-	"scripts": {
-		"build": "npm run build:lib & npm run build:es",
-		"build:lib": "tsc --outDir lib --module commonjs",
-		"build:es": "tsc --outDir es --module es2015",
-		"clean": "rimraf es lib coverage",
-		"typecheck": "tsc --noEmit",
-    "test": "jest --runInBand",
+  "name": "proxy-state-tree",
+  "version": "1.0.0-beta4",
+  "description": "An implementation of the Mobx/Vue state tracking approach, for library authors",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "(npm run build:lib & npm run build:es) && npm run build:dist",
+    "build:lib": "tsc --outDir lib --module commonjs",
+    "build:es": "tsc --outDir es --module es2015",
+    "build:dist": "webpack --config webpack.config.js",
+    "clean": "rimraf es lib coverage",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --runInBand && npm run test:size",
     "test:watch": "jest --watch --updateSnapshot --coverage false",
-		"prebuild": "npm run clean",
-		"postbuild": "rimraf {lib,es}/**/__tests__",
+    "test:size": "bundlesize",
+    "prebuild": "npm run clean",
+    "postbuild": "rimraf {lib,es}/**/__tests__",
     "posttest": "npm run typecheck"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/christianalfoni/proxy-state-tree.git"
-	},
-	"keywords": [
-		"state",
-		"proxy",
-		"mobx",
-		"vue",
-		"store"
-	],
-	"author": "Christian Alfoni",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/christianalfoni/proxy-state-tree/issues"
-	},
-	"homepage": "https://github.com/christianalfoni/proxy-state-tree#readme",
-	"dependencies": {
-		"is-plain-obj": "^1.1.0"
-	}
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/christianalfoni/proxy-state-tree.git"
+  },
+  "keywords": [
+    "state",
+    "proxy",
+    "mobx",
+    "vue",
+    "store"
+  ],
+  "author": "Christian Alfoni",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/christianalfoni/proxy-state-tree/issues"
+  },
+  "homepage": "https://github.com/christianalfoni/proxy-state-tree#readme",
+  "dependencies": {
+    "is-plain-obj": "^1.1.0"
+  },
+  "devDependencies": {
+    "bundlesize": "^0.17.2",
+    "terser-webpack-plugin": "^1.3.0",
+    "webpack": "^4.35.0"
+  },
+  "bundlesize": [
+    {
+      "path": "./dist/proxy-state-tree.min.js",
+      "maxSize": "3 kB"
+    }
+  ]
 }

--- a/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
+++ b/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
@@ -27,6 +27,8 @@ export class Proxifier {
   }
 
   ensureMutationTrackingIsEnabled(path) {
+    if (process.env.NODE_ENV === 'production') return
+
     if (this.tree.master.options.devmode && !this.tree.canMutate()) {
       throw new Error(
         `proxy-state-tree - You are mutating the path "${path}", but it is not allowed. The following could have happened:
@@ -43,6 +45,8 @@ export class Proxifier {
   }
 
   ensureValueDosntExistInStateTreeElsewhere(value) {
+    if (process.env.NODE_ENV === 'production') return
+
     if (value && value[IS_PROXY] === true) {
       throw new Error(
         `proxy-state-tree - You are trying to insert a value that already exists in the state tree on path "${
@@ -130,7 +134,7 @@ export class Proxifier {
         const method = String(prop)
 
         if (arrayMutations.has(method)) {
-          proxifier.ensureMutationTrackingIsEnabled(nestedPath)
+          /* @__PURE__ */ proxifier.ensureMutationTrackingIsEnabled(nestedPath)
           return (...args) => {
             const mutationTree = proxifier.getMutationTree()
 
@@ -141,11 +145,17 @@ export class Proxifier {
               hasChangedValue: true,
             })
 
-            return target[prop](
-              ...args.map((arg) =>
-                proxifier.ensureValueDosntExistInStateTreeElsewhere(arg)
+            if (process.env.NODE_ENV === 'production') {
+              return target[prop](...args)
+            } else {
+              return target[prop](
+                ...args.map((arg) =>
+                  /* @__PURE__ */ proxifier.ensureValueDosntExistInStateTreeElsewhere(
+                    arg
+                  )
+                )
               )
-            )
+            }
           }
         }
 
@@ -158,8 +168,10 @@ export class Proxifier {
       set(target, prop, value) {
         const nestedPath = proxifier.concat(path, prop)
 
-        proxifier.ensureMutationTrackingIsEnabled(nestedPath)
-        proxifier.ensureValueDosntExistInStateTreeElsewhere(value)
+        /* @__PURE__ */ proxifier.ensureMutationTrackingIsEnabled(nestedPath)
+        /* @__PURE__ */ proxifier.ensureValueDosntExistInStateTreeElsewhere(
+          value
+        )
 
         const mutationTree = proxifier.getMutationTree()
 
@@ -243,8 +255,10 @@ export class Proxifier {
       set(target, prop, value) {
         const nestedPath = proxifier.concat(path, prop)
 
-        proxifier.ensureMutationTrackingIsEnabled(nestedPath)
-        proxifier.ensureValueDosntExistInStateTreeElsewhere(value)
+        /* @__PURE__ */ proxifier.ensureMutationTrackingIsEnabled(nestedPath)
+        /* @__PURE__ */ proxifier.ensureValueDosntExistInStateTreeElsewhere(
+          value
+        )
 
         let objectChangePath
 
@@ -273,7 +287,7 @@ export class Proxifier {
       deleteProperty(target, prop) {
         const nestedPath = proxifier.concat(path, prop)
 
-        proxifier.ensureMutationTrackingIsEnabled(nestedPath)
+        /* @__PURE__ */ proxifier.ensureMutationTrackingIsEnabled(nestedPath)
 
         let objectChangePath
         if (prop in target) {

--- a/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
+++ b/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
@@ -16,6 +16,9 @@ const arrayMutations = new Set([
   'copyWithin',
 ])
 
+const getValue = (proxyOrValue) =>
+  proxyOrValue && proxyOrValue[IS_PROXY] ? proxyOrValue[VALUE] : proxyOrValue
+
 export class Proxifier {
   CACHED_PROXY = Symbol('CACHED_PROXY')
   constructor(private tree: TTree) {}
@@ -105,7 +108,8 @@ export class Proxifier {
         if (prop === PATH) return path
         if (prop === VALUE) return value
         if (prop === 'indexOf') {
-          return (arg) => value.indexOf(arg && arg[IS_PROXY] ? arg[VALUE] : arg)
+          return (searchTerm, offset) =>
+            value.indexOf(getValue(searchTerm), getValue(offset))
         }
         if (
           prop === 'length' ||

--- a/packages/node_modules/proxy-state-tree/src/index.test.ts
+++ b/packages/node_modules/proxy-state-tree/src/index.test.ts
@@ -369,6 +369,17 @@ describe('ARRAYS', () => {
     })
   })
 
+  test('should create proxies of arrays', () => {
+    const state = {
+      foo: [],
+    }
+    const tree = new ProxyStateTree(state)
+    const trackStateTree = tree.getTrackStateTree().track(() => {})
+    const foo = trackStateTree.state.foo
+
+    expect(foo[IS_PROXY]).toBeTruthy()
+  })
+
   describe('MUTATIONS', () => {
     test('should throw when mutating without tracking mutations', () => {
       const state = {
@@ -493,24 +504,15 @@ describe('ARRAYS', () => {
     })
   })
 
-  test('should allow CONCAT of existing array', () => {
+  test('should allow indexOf using proxy values', () => {
     const state = {
-      foo: ['foo'],
+      things: [{ some: 'thing' }],
+      ids: [2, 1, 1, 1, 2],
     }
     const tree = new ProxyStateTree(state)
-    const mutationTree = tree.getMutationTree()
-    mutationTree.state.foo = mutationTree.state.foo.concat('bar')
-
-    expect(mutationTree.mutations).toEqual([
-      {
-        method: 'set',
-        path: 'foo',
-        args: [['foo', 'bar']],
-        hasChangedValue: true,
-      },
-    ])
-
-    expect(state.foo).toEqual(['foo', 'bar'])
+    expect(tree.state.things.indexOf(tree.state.things[0])).toEqual(0)
+    expect(tree.state.ids.indexOf(2)).toEqual(0)
+    expect(tree.state.ids.indexOf(2, 1)).toEqual(4)
   })
 })
 

--- a/packages/node_modules/proxy-state-tree/webpack.config.js
+++ b/packages/node_modules/proxy-state-tree/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path')
+const TerserPlugin = require('terser-webpack-plugin')
+
+module.exports = {
+  mode: 'production',
+  entry: path.resolve('./es/index.js'),
+  output: {
+    path: path.resolve('dist'),
+    filename: 'proxy-state-tree.min.js',
+  },
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        test: /\.js(\?.*)?$/i,
+        parallel: true,
+        sourceMap: true,
+        terserOptions: {
+          module: true,
+        },
+      }),
+    ],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        include: path.resolve('src'),
+        options: {
+          presets: ['@babel/preset-env'],
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
Some stuff in this PR:
* fixed the second argument to indexOf and adding a test for it too 
* create a release bundle similar to overmind and tests it's size, size budget is 3KB (gzip) for now (that is currently ~50% of overmind). 
* removed the dev messages in production (saves 0,25KB gzip) and optimised the calling of methods by not having to go though a `.map` call on all arguments. 
