### PR TITLE
docs(proxy-state-tree): extend error message to mention another potential root cause

### DIFF
--- a/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
+++ b/packages/node_modules/proxy-state-tree/src/Proxyfier.ts
@@ -78,9 +78,10 @@ export class Proxifier {
     if (this.tree.master.options.devmode && !this.tree.canMutate()) {
       throw new Error(
         `proxy-state-tree - You are mutating the path "${path}", but it is not allowed. The following could have happened:
-        
+
         - You are passing state to a 3rd party tool trying to manipulate the state
         - You are running asynchronous code and forgot to "await" its execution
+        - You are attempting to mutate state outside of an action
         `
       )
     }


### PR DESCRIPTION
As per [our twitter conversation](https://twitter.com/muditameta/status/1184882402897911810?s=21)