### PR TITLE
fix syntax on writing tests guide

### DIFF
--- a/packages/overmind-website/examples/guide/writingtests/actionsnapshot.ts
+++ b/packages/overmind-website/examples/guide/writingtests/actionsnapshot.ts
@@ -24,7 +24,7 @@ describe('Actions', () => {
     })
     test('should handle errors', async () => {
       const overmind = createOvermindMock(config, {
-        api = {
+        api: {
           getPost() {
             throw new Error('test')
           }


### PR DESCRIPTION
- fix `=` in object to `:` in writing tests docs