### PR TITLE
check for devtools presence in statechart

### DIFF
--- a/packages/node_modules/overmind/src/config/statechart.ts
+++ b/packages/node_modules/overmind/src/config/statechart.ts
@@ -154,7 +154,7 @@ export function statechart<C extends IConfiguration, S extends string>(
         statePath.pop()
       }
 
-      if (process.env.NODE_ENV === 'development') {
+      if (process.env.NODE_ENV === 'development' && instance.devtools) {
         instance.devtools.send({
           type: 'chart',
           data: {
@@ -265,7 +265,7 @@ export function statechart<C extends IConfiguration, S extends string>(
             traverseNewPath.pop()
           }
 
-          if (process.env.NODE_ENV === 'development') {
+          if (process.env.NODE_ENV === 'development' && currentInstance.devtools) {
             currentInstance.devtools.send({
               type: 'chart',
               data: {


### PR DESCRIPTION
only send to devtools if there devtools has been initialized

I was setting up an overmind store and using `statechart` in an mdx-deck project which when setting up overmind, it does not reach the `initializeDevtools` step and `statechart` errors.