### PR TITLE
Fix typo in error message from overmind mock

### DIFF
--- a/packages/node_modules/overmind/src/index.ts
+++ b/packages/node_modules/overmind/src/index.ts
@@ -165,7 +165,7 @@ export function createOvermindMock<Config extends IConfiguration>(
 
           if (!mockedEffect || (mockedEffect && !mockedEffect[effect.method])) {
             throw new Error(
-              `The effect "${effect.name}" with metod ${
+              `The effect "${effect.name}" with method ${
                 effect.method
               } has not been mocked`
             )


### PR DESCRIPTION
I got this error when I forgot to mock out an effect.