### PR TITLE
Fix resolve state typing.

### DIFF
--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -154,7 +154,7 @@ export interface Events {
 export type ResolveState<State extends IState | null> = State extends undefined
   ? State
   : {
-      [P in keyof State]: State[P] extends (parent: ResolveState<IState>, root: any) => any
+      [P in keyof State]: State[P] extends (parent: any, root: any) => any
         ? ReturnType<State[P]>
         : State[P] extends Array<any>
         ? State[P]


### PR DESCRIPTION
Hi @christianalfoni ! This change breaks if we are not using IState (State extends null).

Not sure why it worked with `IDerive<IConfiguration, IState, any>`.

I don't think we need to type `parent` when testing the `extends` where the actual code simply tests for `typeof xxx === 'function'` (in Proxifier).

https://github.com/cerebral/overmind/blob/next/packages/node_modules/proxy-state-tree/src/Proxyfier.ts#L303