### PR TITLE
Fix issue with statemachines maintaining state through test executions

### DIFF
--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -1,4 +1,4 @@
-import { EventType, IAction, Overmind, SERIALIZE, createOvermindMock, rehydrate } from './'
+import { EventType, IAction, Overmind, SERIALIZE, createOvermindMock, rehydrate, statemachine, Statemachine } from './'
 import { namespaced } from './config'
 
 function toJSON(obj) {
@@ -416,6 +416,45 @@ describe('Overmind mock', () => {
     const mock = createOvermindMock(config)
     await mock.actions.updateValue()
     expect(mock.state.valuePlusTwo).toEqual(17)
+    done()
+  })
+
+  test('should reset statemachines', async (done) => {
+    type State = {
+      machine: Statemachine<'FOO' | 'BAR' | 'BAZ'>
+    }
+
+    const state: State = {
+      machine: statemachine<'FOO' | 'BAR' | 'BAZ'>({
+        initial: 'FOO',
+        states: {
+          FOO: ['BAR', 'BAZ'],
+          BAR: [],
+          BAZ: []
+        }
+      })
+    }
+
+    const transitionBAR: Action = ({ state }) => {
+      state.machine.BAR()
+    }
+    const transitionBAZ: Action = ({ state }) => {
+      state.machine.BAZ()
+    }
+    const actions = { transitionBAR, transitionBAZ }
+    const config = { state, actions }
+    type Config = typeof config
+    interface Action<Value = void> extends IAction<Config, Value> { }
+
+    const mock = createOvermindMock(config)
+    expect(mock.state.machine.current).toBe('FOO')
+    await mock.actions.transitionBAR()
+    expect(mock.state.machine.current).toBe('BAR')
+
+    const newMock = createOvermindMock(config)
+    expect(newMock.state.machine.current).toBe('FOO')
+    await newMock.actions.transitionBAZ()
+    expect(newMock.state.machine.current).toBe('BAZ')
     done()
   })
 })

--- a/packages/node_modules/overmind/src/utils.ts
+++ b/packages/node_modules/overmind/src/utils.ts
@@ -1,5 +1,6 @@
 import isPlainObject from 'is-plain-obj'
 import { IMutation, IS_PROXY, VALUE } from 'proxy-state-tree'
+import { Statemachine } from '.'
 
 export const IS_TEST = process.env.NODE_ENV === 'test'
 export const IS_OPERATOR = Symbol('operator')
@@ -82,6 +83,8 @@ export function deepCopy(obj) {
     }, {})
   } else if (Array.isArray(obj)) {
     return obj.map((item) => deepCopy(item))
+  } else if (obj && obj.reset && typeof obj.reset === 'function') {
+    obj.reset()
   }
 
   return obj


### PR DESCRIPTION
Resolves #365 

Since statemachines are instances of objects (and not plain objects) they aren't copied. Instead of going through the whole headache of trying to copy or re-create the statemachine without the definitions, just calling `reset` on the statemachine if it's being copied.