### PR TITLE
Adding support for preact

### DIFF
--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -77,9 +77,7 @@ const useForceRerender = () => {
 }
 
 let currentComponentInstanceId = 0
-const {
-  ReactCurrentOwner,
-} = (react as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+const ReactCurrentOwner = { current: null }
 const useCurrentComponent = () => {
   return ReactCurrentOwner &&
     ReactCurrentOwner.current &&

--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -77,7 +77,7 @@ const useForceRerender = () => {
 }
 
 let currentComponentInstanceId = 0
-const ReactCurrentOwner = { current: null }
+const ReactCurrentOwner = (react as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED && (react as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner
 const useCurrentComponent = () => {
   return ReactCurrentOwner &&
     ReactCurrentOwner.current &&


### PR DESCRIPTION
Regarding support for preact in issue #387 

I looks like overmind imports `ReactCurrentOwner` from  `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` that is exported in React.

I found `ReactCurrentOwner` in React:
https://github.com/facebook/react/blob/master/packages/react/src/ReactCurrentOwner.js

I replaced it with it's value and it works :)

I think its good idea to remove variables with name like this from source code :D 


