### PR TITLE
Fix overmind-graphql missing TS types

### DIFF
--- a/packages/node_modules/overmind-graphql/package.json
+++ b/packages/node_modules/overmind-graphql/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.11.6",
+    "@types/phoenix": "^1.4.4",
     "tslib": "^1.10.0"
   }
 }


### PR DESCRIPTION
Add missing TS types for overmind-graphql. 
It's for solving this error:
```
ERROR in node_modules/overmind-graphql/lib/index.d.ts(2,41):
TS7016: Could not find a declaration file for module 'phoenix'. 'node_modules/phoenix/priv/static/phoenix.js' implicitly has an 'any' type.
  Try `npm install @types/phoenix` if it exists or add a new declaration (.d.ts) file containing `declare module 'phoenix';`
Version: typescript 3.8.3, eslint 6.8.0
```