### PR TITLE
fix(overmind-svelte): add complete typing

### DIFF
--- a/packages/node_modules/overmind-svelte/src/index.ts
+++ b/packages/node_modules/overmind-svelte/src/index.ts
@@ -1,21 +1,27 @@
-import { EventType } from 'overmind'
+import { EventType, Overmind, IReaction, IConfiguration } from 'overmind'
+import { ITrackCallback } from 'proxy-state-tree'
 import { onMount, afterUpdate, onDestroy } from 'svelte'
+import { Readable } from 'svelte/store'
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 
 let nextComponentId = 0
 
-export function createMixin (overmind) {
+export function createMixin<Config extends IConfiguration>(
+  overmind: Overmind<Config>
+) {
   const componentId = nextComponentId++
   let nextComponentInstanceId = 0
   let currentFlushId = 0
 
-  const subscribe = listener => {
+  // Svelte "store contract" https://svelte.dev/docs#Store_contract
+  const subscribe: Readable<any>['subscribe'] = (listener) => {
+    // @ts-ignore
     const tree = overmind.proxyStateTree.getTrackStateTree()
     const componentInstanceId = nextComponentInstanceId++
     let isUpdating = false
 
-    const onUpdate = (mutations, paths, flushId) => {
+    const onUpdate: ITrackCallback = (_mutations, _paths, flushId) => {
       tree.track(onUpdate)
       currentFlushId = flushId
       isUpdating = true
@@ -37,7 +43,7 @@ export function createMixin (overmind) {
           componentId,
           componentInstanceId,
           name: '',
-          paths: Array.from(tree.pathDependencies)
+          paths: Array.from(tree.pathDependencies),
         })
       })
 
@@ -49,7 +55,7 @@ export function createMixin (overmind) {
             componentInstanceId,
             name: '',
             flushId: currentFlushId,
-            paths: Array.from(tree.pathDependencies)
+            paths: Array.from(tree.pathDependencies),
           })
         }
         isUpdating = false
@@ -57,28 +63,31 @@ export function createMixin (overmind) {
     }
 
     return () => {
+      // @ts-ignore
       overmind.proxyStateTree.disposeTree(tree)
       overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
         componentId,
         componentInstanceId: componentInstanceId,
-        name: ''
+        name: '',
       })
     }
   }
 
-  const reaction = (...args) => {
+  const reaction: IReaction<Config> = (...args) => {
     const dispose = overmind.reaction(...args)
 
     onDestroy(() => {
       dispose()
     })
+
+    return dispose
   }
 
   return {
-    state: { ...overmind.state, subscribe},
+    state: { ...overmind.state, subscribe },
     actions: overmind.actions,
     effects: overmind.effects,
     addMutationListener: overmind.addMutationListener,
-    reaction: reaction
+    reaction: reaction,
   }
 }

--- a/packages/node_modules/overmind-svelte/src/index.ts
+++ b/packages/node_modules/overmind-svelte/src/index.ts
@@ -15,7 +15,7 @@ export function createMixin<Config extends IConfiguration>(
   let currentFlushId = 0
 
   // Svelte "store contract" https://svelte.dev/docs#Store_contract
-  const subscribe: Readable<any>['subscribe'] = (listener) => {
+  const subscribe: Readable<Config['state']>['subscribe'] = (listener) => {
     // @ts-ignore
     const tree = overmind.proxyStateTree.getTrackStateTree()
     const componentInstanceId = nextComponentInstanceId++


### PR DESCRIPTION
Add types to `overmind-svelte` now that Svelte properly supports TypeScript.

This shouldn't change any logic, but @mfeitoza might want to review.

I hope this simple type change can make v26!