### PR TITLE
fix(overmind-react): set default config type for hooks and connects

### DIFF
--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -1,14 +1,15 @@
-import 'proxy-state-tree'
-import { unstable_scheduleCallback, unstable_getCurrentPriorityLevel, unstable_cancelCallback } from 'scheduler'
 import {
+  Config as DefaultConfig,
   EventType,
   IConfiguration,
   MODE_SSR,
   Overmind,
-  OvermindMock,
+  OvermindMock
 } from 'overmind'
+import 'proxy-state-tree'
 import { IMutationCallback } from 'proxy-state-tree'
 import * as react from 'react'
+import { unstable_cancelCallback, unstable_getCurrentPriorityLevel, unstable_scheduleCallback } from 'scheduler'
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 const IS_TEST = process.env.NODE_ENV === 'test'
@@ -46,7 +47,7 @@ function getDisplayName(component): string {
   );
 }
 
-export interface IConnect<Config extends IConfiguration> {
+export interface IConnect<Config extends IConfiguration = DefaultConfig> {
   overmind: {
     state: Overmind<Config>['state']
     actions: Overmind<Config>['actions']
@@ -246,23 +247,23 @@ const useReaction =  <Config extends IConfiguration>(): Overmind<Config>['reacti
   return overmind.reaction
 }
 
-export const createStateHook: <Config extends IConfiguration>() => () => Overmind<Config>['state'] = () => {
+export const createStateHook: <Config extends IConfiguration = DefaultConfig>() => () => Overmind<Config>['state'] = () => {
   return useState as any
 }
 
-export const createActionsHook: <Config extends IConfiguration>() => () => Overmind<Config>['actions'] = ()=> {
+export const createActionsHook: <Config extends IConfiguration = DefaultConfig>() => () => Overmind<Config>['actions'] = ()=> {
   return useActions as any
 }
 
-export const createEffectsHook: <Config extends IConfiguration>() => () => Overmind<Config>['effects'] = () => {
+export const createEffectsHook: <Config extends IConfiguration = DefaultConfig>() => () => Overmind<Config>['effects'] = () => {
   return useEffects as any
 }
 
-export const createReactionHook: <Config extends IConfiguration>() => () => Overmind<Config>['reaction'] = () => {
+export const createReactionHook: <Config extends IConfiguration = DefaultConfig>() => () => Overmind<Config>['reaction'] = () => {
   return useReaction as any
 }
 
-export const createHook: <Config extends IConfiguration>() => () => {
+export const createHook: <Config extends IConfiguration = DefaultConfig>() => () => {
   state: Overmind<Config>['state']
   actions: Overmind<Config>['actions']
   effects: Overmind<Config>['effects']
@@ -285,7 +286,7 @@ export const createHook: <Config extends IConfiguration>() => () => {
   }
 }
 
-export const createConnect: <ThisConfig extends IConfiguration>() => <Props>(component: IReactComponent<
+export const createConnect: <ThisConfig extends IConfiguration = DefaultConfig>() => <Props>(component: IReactComponent<
   Props & {
     overmind: {
       state: Overmind<ThisConfig>['state']


### PR DESCRIPTION
This change makes it so we no longer have to use `createHook<typeof config>()`, as long as `Config`
declaration is overriden we can just do `createHook()`.