### PR TITLE
fix(overmind-statechart): avoid throwing config error when fast refresh kicks in

### DIFF
--- a/packages/node_modules/overmind-statechart/src/index.ts
+++ b/packages/node_modules/overmind-statechart/src/index.ts
@@ -272,13 +272,13 @@ export function statechart<
   const actions = config.actions || {}
   const state = config.state || {}
 
-  if (config.state && (config.state as any).states) {
+  if (currentInstance !== undefined && config.state && (config.state as any).states) {
     throw new Error(
       `Overmind statecharts: You have already defined the state "states" in your configuration. Statecharts needs this, please rename it`
     )
   }
 
-  if (config.state && (config.state as any).matches) {
+  if (currentInstance !== undefined && config.state && (config.state as any).matches) {
     throw new Error(
       `Overmind statecharts: You have already defined the state "matches" in your configuration. Statecharts needs this, please rename it`
     )


### PR DESCRIPTION
React's fast refresh reruns `statechart` when a module that contains this call is edited.
As the statechart was already initialized, a config error was thrown since `states` and `matches` were already present in the current state.
To avoid throwing this error, it is now only thrown when the statechart is first initialized.