### PR TITLE
fix(overmind): match actions in ResolveAction

### DIFF
--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -172,13 +172,30 @@ export type ResolveAction<T> = T extends IOperator<void, infer R>
   : never
 
 export interface ContextFunction<P extends any, R extends any> {
-  (context: { state: any; actions: any; effects: any }, payload: P): R
+  (
+    context: {
+      state: any
+      actions: any
+      effects: any
+      reaction: any
+      addMutationListener: any
+      addFlushListener: any
+    },
+    payload: P
+  ): R
 }
 
 // This resolves promises to its values, cause that is how operators work
 export interface OperatorContextFunction<P extends any, R extends any> {
   (
-    context: { state: any; actions: any; effects: any },
+    context: {
+      state: any
+      actions: any
+      effects: any
+      reaction: any
+      addMutationListener: any
+      addFlushListener: any
+    },
     payload: P extends Promise<infer PP> ? PP : P
   ): R
 }


### PR DESCRIPTION
@christianalfoni I may have seriously misunderstood the typing, but it looks like `IContext` was replaced with a shell of `IContext` to avoid circular issues. This seems like a good place to do that, however, the entire IContext has to be matched. Add the missing (and new) IContext members to the shell.