### PR TITLE
Alter test for process

### DIFF
--- a/packages/node_modules/overmind-react/src/index.ts
+++ b/packages/node_modules/overmind-react/src/index.ts
@@ -17,7 +17,7 @@ import {
 const IS_PRODUCTION = ENVIRONMENT === 'production'
 const IS_TEST = ENVIRONMENT === 'test'
 const isNode =
-  !IS_TEST && process && process.title && process.title.includes('node')
+  !IS_TEST && typeof process !== "undefined" && process.title && process.title.includes('node')
 
 export type IReactComponent<P = any> =
   | react.StatelessComponent<P>

--- a/packages/node_modules/overmind/src/Overmind.ts
+++ b/packages/node_modules/overmind/src/Overmind.ts
@@ -47,7 +47,7 @@ export class Overmind<ThisConfig extends IConfiguration>
   ) {
     const name = options.name || 'OvermindApp'
     const devEnv = options.devEnv || 'development'
-    const isNode = process && process.title && process.title.includes('node')
+    const isNode = typeof process !== "undefined" && process.title && process.title.includes('node')
 
     this.delimiter = options.delimiter || '.'
     this.isStrict = Boolean(options.strict)


### PR DESCRIPTION
Vite/rollup does not shim `global`, `process` etc which are not available in a browser (https://github.com/vitejs/vite/issues/1689).  This results in  the blocking error 'process is not defined' since the variable does not exist.

The current check for `isNode` look like this:
 `const isNode = !IS_TEST && process && process.title && process.title.includes('node')`


Altering this as follows ensures this is handled properly: 
`const isNode =
  !IS_TEST && typeof process !== "undefined" && process.title && process.title.includes('node')` solves this issue.