### PR TITLE
feat(overmind): allow payload param of action to be optional

### DIFF
--- a/packages/node_modules/overmind/src/index.test.ts
+++ b/packages/node_modules/overmind/src/index.test.ts
@@ -48,6 +48,23 @@ function createDefaultOvermind() {
   const changeValue = ({ actions }: Context, value: { isAwesome: boolean }) => {
     value.isAwesome = !value.isAwesome
   }
+  const changeOptionalFoo = (context: Context, newFoo?: string) => {
+    if (newFoo !== undefined) {
+      context.state.foo = newFoo
+    }
+    else {
+      context.state.foo = 'default-foo'
+    }
+  }
+  const asyncChangeOptionalFoo = async (context: Context, newFoo?: string) => {
+    await Promise.resolve()
+    if (newFoo !== undefined) {
+      context.state.foo = newFoo
+    }
+    else {
+      context.state.foo = 'async-default-foo'
+    }
+  }
   const changeFormValue = (
     _: Context,
     payload: {
@@ -72,6 +89,8 @@ function createDefaultOvermind() {
     changeValue,
     waitAndChangeFoo,
     rehydrateAction,
+    changeOptionalFoo,
+    asyncChangeOptionalFoo
   }
   const effects = {
     hello() {
@@ -426,5 +445,20 @@ describe('Overmind', () => {
     expect(app.state.foo).toBe('bar2')
     changeFoo()
     expect(app.state.foo).toBe('replaced!')
+  })
+  test('should allow actions with optional parameter', async () => {
+    const app = createDefaultOvermind()
+    app.actions.changeOptionalFoo();
+    expect(app.state.foo).toBe('default-foo')
+    await app.actions.asyncChangeOptionalFoo();
+    expect(app.state.foo).toBe('async-default-foo')
+
+    const newFoo = 'new-foo';
+    app.actions.changeOptionalFoo(newFoo);
+    expect(app.state.foo).toBe(newFoo)
+
+    const newAsyncFoo = 'new-async-foo';
+    await app.actions.asyncChangeOptionalFoo(newAsyncFoo);
+    expect(app.state.foo).toBe(newAsyncFoo)
   })
 })

--- a/packages/node_modules/overmind/src/internalTypes.ts
+++ b/packages/node_modules/overmind/src/internalTypes.ts
@@ -161,10 +161,14 @@ type NestedActions = {
 
 export type ResolveAction<T> = T extends IOperator<void, infer R>
   ? () => Promise<R>
+  : T extends IOperator<infer P | undefined, infer R>
+  ? (payload?: P) => Promise<R>
   : T extends IOperator<infer P, infer R>
   ? (payload: P) => Promise<R>
   : T extends IAction<void, infer R>
   ? () => R
+  : T extends IAction<infer P | undefined, infer R> 
+  ? (payload?: P) => R
   : T extends IAction<infer P, infer R>
   ? (payload: P) => R
   : T extends NestedActions


### PR DESCRIPTION
This allows to specify actions with optional params and calling them without a parameter, e.g.:

    const actionWithOptionalParam = (context: Context, value?: string) => {
        // ...
    }