### PR TITLE
fix(overmind-react): add missing dependency to `react`

### DIFF
--- a/packages/node_modules/overmind-angular/package.json
+++ b/packages/node_modules/overmind-angular/package.json
@@ -26,11 +26,11 @@
   ],
   "files": [
     "lib",
-    "es",
-    "react"
+    "es"
   ],
   "dependencies": {
-    "overmind": "next"
+    "overmind": "next",
+    "@angular/core": "*"
   },
   "devDependencies": {
     "@types/node": "^12.11.6",

--- a/packages/node_modules/overmind-react/package.json
+++ b/packages/node_modules/overmind-react/package.json
@@ -28,11 +28,11 @@
   ],
   "files": [
     "lib",
-    "es",
-    "react"
+    "es"
   ],
   "dependencies": {
-    "overmind": "next"
+    "overmind": "next",
+    "react": "*"
   },
   "devDependencies": {
     "@types/node": "^12.11.6",

--- a/repo-cooker.js
+++ b/repo-cooker.js
@@ -5,9 +5,5 @@ export const cooker = Cooker(process.argv, {
     host: 'localhost:8787, reconnect: false',
   },
   path: '.',
-  packagesGlobs: [
-    'packages/node_modules/*',
-    'packages/overmind-website',
-    'packages/demos/*',
-  ],
+  packagesGlobs: ['packages/node_modules/*'],
 })


### PR DESCRIPTION
without this, bundlers fail to dedupe correctly and bundle react with overmind-react resulting in
multiple versions of react and all hooks failing