### PR TITLE
Explicitly declare React dependency

### DIFF
--- a/packages/overmind-react/package.json
+++ b/packages/overmind-react/package.json
@@ -28,11 +28,11 @@
   ],
   "files": [
     "lib",
-    "es",
-    "react"
+    "es"
   ],
   "dependencies": {
-    "overmind": "next"
+    "overmind": "next",
+    "react": "*"
   },
   "devDependencies": {
     "@types/node": "^12.11.6",

--- a/packages/overmind-react/package.json
+++ b/packages/overmind-react/package.json
@@ -31,11 +31,13 @@
     "es"
   ],
   "dependencies": {
-    "overmind": "next",
-    "react": "*"
+    "overmind": "next"
   },
   "devDependencies": {
     "@types/node": "^12.11.6",
     "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "react": "*"
   }
 }


### PR DESCRIPTION
Explicitly declare React dependency, so build tools like Snowpack will use a single copy of the library. This fixes #519.