### PR TITLE
Fix blocker bug in overmind-vue

### DIFF
--- a/packages/overmind-vue/src/vue3.ts
+++ b/packages/overmind-vue/src/vue3.ts
@@ -67,7 +67,7 @@ export function createStateHook<Config extends IConfiguration>(): StateHook<
       )
 
       if (!value.tree) {
-        value.tree = overmindInstance.proxyStateTree.getTrackStateTree()
+        value.tree = overmindInstance.proxyStateTreeInstance.getTrackStateTree()
         value.componentInstanceId = componentInstanceId++
         value.onUpdate = (_: any, __: any, flushId: number) => {
           value.currentFlushId = flushId


### PR DESCRIPTION
There is a wrong name used. It should be `proxyStateTreeInstance` instead of `proxyStateTree`