### PR TITLE
Fix blocker (typo error) in overmind-vue

### DIFF
--- a/packages/overmind-vue/src/vue3.ts
+++ b/packages/overmind-vue/src/vue3.ts
@@ -120,7 +120,7 @@ export function createStateHook<
       onBeforeUnmount(() => {
         if (overmindInstance.mode.mode === MODE_SSR) return
 
-        overmindInstance.proxyStateTree.disposeTree(value.tree)
+        overmindInstance.proxyStateTreeInstance.disposeTree(value.tree)
         if (IS_PRODUCTION) {
           return
         }


### PR DESCRIPTION
It should be proxyStateTreeInstance, not proxyStateTree.  (this file had 2 times this typo, the first was addressed in https://github.com/cerebral/overmind/pull/521/commits/0606a7e5dcc537aca3a8c65899f1c7b47ecf5f12), this is the second one