### PR TITLE
fix(overmind-graphql): Add 'ReadonlyArray' interface to type 'Literals'

### DIFF
--- a/packages/overmind-graphql/src/index.ts
+++ b/packages/overmind-graphql/src/index.ts
@@ -123,7 +123,7 @@ function createError(message: string) {
   throw new Error(`OVERMIND-GRAPHQL: ${message}`)
 }
 
-type Literals = string | string[]
+type Literals = string | ReadonlyArray<string>
 
 export const gql = (
   literals: Literals,


### PR DESCRIPTION
PR fixes the issue described in https://github.com/cerebral/overmind/issues/526

<img width="504" alt="Screen Shot 2021-07-05 at 12 37 33 PM" src="https://user-images.githubusercontent.com/35598345/124458859-cb8bdc00-dd8d-11eb-9cdd-f8db7030221f.png">
