### PR TITLE
Make loglevel of "missing devtools error" configurable

### DIFF
--- a/packages/overmind/src/Devtools.ts
+++ b/packages/overmind/src/Devtools.ts
@@ -1,3 +1,4 @@
+import { LogLevel } from './internalTypes'
 import { SERIALIZE } from './rehydrate'
 
 export type Message = {
@@ -23,7 +24,7 @@ export class Devtools {
   private hasWarnedReconnect: boolean = false
   private reconnectInterval: number = 10000
   private name: string
-  constructor(name: string) {
+  constructor(name: string, private logLevel: LogLevel = 'error') {
     this.name =
       typeof location !== 'undefined' &&
       location.search.includes('OVERMIND_DEVTOOL')
@@ -48,7 +49,7 @@ export class Devtools {
       this.flushBuffer()
     }
     this.ws.onerror = () => {
-      console.error(
+      console[this.logLevel](
         `OVERMIND DEVTOOLS: Not able to connect. You are trying to connect to "${host}", but there was no devtool there. Try the following:
         
           - Make sure you are running the latest version of the devtools, using "npx overmind-devtools@latest" or install latest extension for VSCode

--- a/packages/overmind/src/Overmind.ts
+++ b/packages/overmind/src/Overmind.ts
@@ -6,7 +6,7 @@ import { Devtools, DevtoolsMessage } from './Devtools'
 import * as internalTypes from './internalTypes'
 import { proxifyEffects } from './proxyfyEffects'
 import { rehydrate } from './rehydrate'
-import { IConfiguration, IReaction, IContext } from './types'
+import { IConfiguration, IContext, IReaction } from './types'
 import * as utils from './utils'
 
 const hotReloadingCache = {}
@@ -144,7 +144,8 @@ export class Overmind<ThisConfig extends IConfiguration>
           name,
           eventHub,
           proxyStateTreeInstance.sourceState,
-          configuration.actions
+          configuration.actions,
+          options.devtoolsLogLevel
         )
       } else if (options.devtools !== false) {
         warning +=
@@ -695,9 +696,16 @@ export class Overmind<ThisConfig extends IConfiguration>
     })
   }
 
-  private initializeDevtools(host, name, eventHub, initialState, actions) {
+  private initializeDevtools(
+    host,
+    name,
+    eventHub,
+    initialState,
+    actions,
+    logLevel: internalTypes.LogLevel
+  ) {
     if (utils.ENVIRONMENT === 'production') return
-    const devtools = new Devtools(name)
+    const devtools = new Devtools(name, logLevel)
     devtools.connect(
       host,
       (message: DevtoolsMessage) => {

--- a/packages/overmind/src/Overmind.ts
+++ b/packages/overmind/src/Overmind.ts
@@ -702,7 +702,7 @@ export class Overmind<ThisConfig extends IConfiguration>
     eventHub,
     initialState,
     actions,
-    logLevel: internalTypes.LogLevel
+    logLevel: internalTypes.LogLevel = 'error'
   ) {
     if (utils.ENVIRONMENT === 'production') return
     const devtools = new Devtools(name, logLevel)

--- a/packages/overmind/src/internalTypes.ts
+++ b/packages/overmind/src/internalTypes.ts
@@ -4,7 +4,6 @@ import {
   IMutationTree,
   ITrackStateTree,
 } from 'proxy-state-tree'
-
 import { IAction, IOperator } from './types'
 
 export type SubType<Base, Condition> = Pick<
@@ -18,6 +17,8 @@ export type NestedPartial<T> = T extends Function
   ? T
   : Partial<{ [P in keyof T]: NestedPartial<T[P]> }>
 
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
 export type Options = {
   delimiter?: string
   name?: string
@@ -26,6 +27,7 @@ export type Options = {
   logProxies?: boolean
   hotReloading?: boolean
   strict?: boolean
+  devtoolsLogLevel?: LogLevel
 }
 
 export type DefaultMode = {


### PR DESCRIPTION
It is a bit disturbing to get a huge red error in console when starting a dev app without devtools running. A warning seems more appropriate.