### PR TITLE
Fix bug with unmounted component when working in development mode

### DIFF
--- a/packages/overmind-react/src/index.ts
+++ b/packages/overmind-react/src/index.ts
@@ -136,6 +136,7 @@ const useState = <Context extends IContext<{ state: {} }>>(
       })
 
       return () => {
+        mountedRef.current = false
         overmind.eventHub.emitAsync(EventType.COMPONENT_REMOVE, {
           componentId: component.__componentId,
           componentInstanceId,


### PR DESCRIPTION
There is a bug while working in the development mode when components unmount: 

Minimum reproduction code: https://github.com/dopeshot/ionic-overmind-cant-perform-state-update

How to reproduce: 
1. Go to the other page
2. Increase the count (modify state)
3. Go back to main page
4. Increase the count (modify state) ==> Go to console and there is the error
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

Video of the issue: https://www.youtube.com/watch?v=5w6r1_lxoS8

StackOverflow discussion: https://stackoverflow.com/questions/70744871/ionic-react-overmind-cant-perform-a-react-state-update-on-an-unmounted-componen