### PR TITLE
fix: Type U does not satisfy the constraint '{}' ts(2344)

### DIFF
--- a/packages/overmind/src/rehydrate.ts
+++ b/packages/overmind/src/rehydrate.ts
@@ -77,7 +77,7 @@ type ExtracType<T extends {}, K> = {
     : never
 }
 
-type ExtractDeepType<T extends {}, K, U = ExtracType<T, K>> = {
+type ExtractDeepType<T extends {}, K, U extends {} = ExtracType<T, K>> = {
   [P in ExcludeNever<U>]: U[P]
 }
 


### PR DESCRIPTION
Got an error with the newest TypeScript, this small fix seems sufficient to make it go away.

![image](https://user-images.githubusercontent.com/594564/201545759-06e6ab2e-9035-4a83-8892-1f7497e54070.png)
