### PR TITLE
Enable self-contained namespaced modules with automatic scoping

### DIFF
--- a/packages/overmind/src/Overmind.ts
+++ b/packages/overmind/src/Overmind.ts
@@ -380,15 +380,140 @@ export class Overmind<ThisConfig extends IConfiguration>
     return execution
   }
 
+  private createScopedProxy(target: any, namespacePath: string[]): any {
+    if (!namespacePath.length) {
+      return target
+    }
+
+    return new Proxy(target, {
+      get: (obj, prop) => {
+        // Allow direct access to symbols and internal properties
+        if (typeof prop === 'symbol' || String(prop).startsWith('__')) {
+          return obj[prop]
+        }
+
+        const namespaceObj = namespacePath.reduce(
+          (aggr, key) => aggr?.[key],
+          obj
+        )
+
+        // Special handling for StateMachine: bind methods to preserve context
+        if (utils.isStateMachine(namespaceObj)) {
+          // Check if property exists in the StateMachine
+          if (prop in namespaceObj) {
+            const value = namespaceObj[prop]
+            // If it's a method, bind it to the StateMachine instance
+            if (typeof value === 'function') {
+              return value.bind(namespaceObj)
+            }
+            return value
+          }
+          // Property doesn't exist in StateMachine, fall back to root
+          return obj[prop]
+        }
+
+        // Standard scoping: prefer namespace, fallback to root
+        const value =
+          namespaceObj && prop in namespaceObj ? namespaceObj[prop] : obj[prop]
+
+        // If we got a function from the namespace object (like an effect method),
+        // bind it to maintain the correct 'this' context
+        if (
+          namespaceObj &&
+          prop in namespaceObj &&
+          typeof value === 'function'
+        ) {
+          return value.bind(namespaceObj)
+        }
+
+        return value
+      },
+
+      set: (obj, prop, value) => {
+        const namespaceObj = namespacePath.reduce(
+          (aggr, key) => aggr?.[key],
+          obj
+        )
+
+        if (namespaceObj) {
+          namespaceObj[prop] = value
+        } else {
+          obj[prop] = value
+        }
+        return true
+      },
+
+      has: (obj, prop) => {
+        const namespaceObj = namespacePath.reduce(
+          (aggr, key) => aggr?.[key],
+          obj
+        )
+        return (namespaceObj && prop in namespaceObj) || prop in obj
+      },
+
+      ownKeys: (obj) => {
+        const namespaceObj = namespacePath.reduce(
+          (aggr, key) => aggr?.[key],
+          obj
+        )
+
+        if (utils.isStateMachine(namespaceObj)) {
+          return Object.keys(namespaceObj)
+        }
+
+        const namespaceKeys = namespaceObj ? Object.keys(namespaceObj) : []
+        const rootKeys = Object.keys(obj)
+        return Array.from(new Set([...namespaceKeys, ...rootKeys]))
+      },
+
+      getOwnPropertyDescriptor: (obj, prop) => {
+        const namespaceObj = namespacePath.reduce(
+          (aggr, key) => aggr?.[key],
+          obj
+        )
+
+        if (namespaceObj && prop in namespaceObj) {
+          return (
+            Object.getOwnPropertyDescriptor(namespaceObj, prop) || {
+              configurable: true,
+              enumerable: true,
+            }
+          )
+        }
+
+        return (
+          Object.getOwnPropertyDescriptor(obj, prop) || {
+            configurable: true,
+            enumerable: true,
+          }
+        )
+      },
+    })
+  }
+
   private createContext(execution, tree) {
+    const namespacePath = execution.namespacePath || []
+
+    // Create base actions proxy
+    const actionsProxy = utils.createActionsProxy(this.actions, (action) => {
+      return (value) => action(value, execution.isRunning ? execution : null)
+    })
+
     return {
-      state: tree.state,
-      actions: utils.createActionsProxy(this.actions, (action) => {
-        return (value) => action(value, execution.isRunning ? execution : null)
-      }),
+      state: namespacePath.length
+        ? this.createScopedProxy(tree.state, namespacePath)
+        : tree.state,
+      actions: namespacePath.length
+        ? this.createScopedProxy(actionsProxy, namespacePath)
+        : actionsProxy,
       execution,
       proxyStateTree: this.proxyStateTreeInstance,
-      effects: this.trackEffects(this.effects, execution),
+      effects: namespacePath.length
+        ? this.createScopedProxy(
+            this.trackEffects(this.effects, execution),
+            namespacePath
+          )
+        : this.trackEffects(this.effects, execution),
       addNamespace: this.addNamespace.bind(this),
       reaction: this.reaction.bind(this),
       addMutationListener: this.addMutationListener.bind(this),

--- a/packages/overmind/src/index.test.ts
+++ b/packages/overmind/src/index.test.ts
@@ -1,5 +1,13 @@
-import { EventType, IContext, Overmind, SERIALIZE, rehydrate } from './'
-import { namespaced } from './config'
+import {
+  EventType,
+  IContext,
+  Overmind,
+  SERIALIZE,
+  createOvermind,
+  rehydrate,
+  statemachine,
+} from '..'
+import { merge, namespaced } from './config'
 
 function toJSON(obj) {
   return JSON.parse(JSON.stringify(obj))
@@ -469,5 +477,694 @@ describe('Overmind', () => {
     const newAsyncFoo = 'new-async-foo'
     await app.actions.asyncChangeOptionalFoo(newAsyncFoo)
     expect(app.state.foo).toBe(newAsyncFoo)
+  })
+})
+
+describe('Namespaced module scoping', () => {
+  test('should allow module actions to access own state without namespace', () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            currentPath: '/',
+          },
+          actions: {
+            navigate({ state }) {
+              state.currentPath = '/new-path'
+            },
+          },
+        },
+      })
+    )
+
+    expect(app.state.router.currentPath).toBe('/')
+    app.actions.router.navigate()
+    expect(app.state.router.currentPath).toBe('/new-path')
+  })
+
+  test('should allow module actions to access own effects without namespace', () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            baseUrl: '',
+          },
+          effects: {
+            getBaseUrl() {
+              return 'https://example.com'
+            },
+          },
+          actions: {
+            initialize({ state, effects }) {
+              state.baseUrl = effects.getBaseUrl()
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.initialize()
+    expect(app.state.router.baseUrl).toBe('https://example.com')
+  })
+
+  test('should allow module actions to call own actions without namespace', () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            path: '/',
+            history: [] as string[],
+          },
+          actions: {
+            addToHistory({ state }, path: string) {
+              state.history.push(path)
+            },
+            navigate({ state, actions }, path: string) {
+              state.path = path
+              actions.addToHistory(path)
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.navigate('/about')
+    expect(app.state.router.path).toBe('/about')
+    expect(app.state.router.history).toEqual(['/about'])
+  })
+
+  test('should allow module to access nested properties within its namespace', () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            config: {
+              baseUrl: '/',
+              history: {
+                maxSize: 10,
+              },
+            },
+          },
+          actions: {
+            updateMaxSize({ state }, size: number) {
+              state.config.history.maxSize = size
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.updateMaxSize(20)
+    expect(app.state.router.config.history.maxSize).toBe(20)
+  })
+
+  test('should allow module to access shared root-level effects', () => {
+    const app = new Overmind(
+      merge(
+        {
+          effects: {
+            http: {
+              get: () => 'data',
+            },
+          },
+        },
+        namespaced({
+          router: {
+            state: {
+              data: '',
+            },
+            actions: {
+              fetchData({ state, effects }) {
+                state.data = (effects as any).http.get()
+              },
+            },
+          },
+        })
+      )
+    )
+
+    app.actions.router.fetchData()
+    expect(app.state.router.data).toBe('data')
+  })
+
+  test('should allow module to access other modules via root', () => {
+    const app = new Overmind(
+      namespaced({
+        auth: {
+          state: {
+            user: 'John',
+          },
+        },
+        router: {
+          state: {
+            userName: '',
+          },
+          actions: {
+            getUserName({ state }) {
+              // Access other module via root fallback
+              state.userName = (state as any).auth.user
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.getUserName()
+    expect(app.state.router.userName).toBe('John')
+  })
+
+  test('should allow module to call actions from other modules', () => {
+    const app = new Overmind(
+      namespaced({
+        auth: {
+          state: {
+            isLoggedIn: false,
+          },
+          actions: {
+            login({ state }) {
+              state.isLoggedIn = true
+            },
+          },
+        },
+        router: {
+          state: {
+            redirected: false,
+          },
+          actions: {
+            navigateProtected({ state, actions }) {
+              ;(actions as any).auth.login()
+              state.redirected = true
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.navigateProtected()
+    expect(app.state.auth.isLoggedIn).toBe(true)
+    expect(app.state.router.redirected).toBe(true)
+  })
+
+  test('should work with async actions in modules', async () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            loading: false,
+            path: '/',
+          },
+          effects: {
+            async fetchPath() {
+              return '/async-path'
+            },
+          },
+          actions: {
+            async navigate({ state, effects }) {
+              state.loading = true
+              state.path = await effects.fetchPath()
+              state.loading = false
+            },
+          },
+        },
+      })
+    )
+
+    await app.actions.router.navigate()
+    expect(app.state.router.loading).toBe(false)
+    expect(app.state.router.path).toBe('/async-path')
+  })
+
+  test('should work with deeply nested module structures', () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            routes: {
+              home: '/',
+              about: '/about',
+            },
+          },
+          effects: {
+            helpers: {
+              parseRoute(path: string) {
+                return path.toUpperCase()
+              },
+            },
+          },
+          actions: {
+            setRoute({ state, effects }, key: 'home' | 'about') {
+              const path = state.routes[key]
+              state.routes[key] = (effects as any).helpers.parseRoute(path)
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.setRoute('home')
+    expect(app.state.router.routes.home).toBe('/')
+  })
+
+  test('should track mutations in namespaced modules correctly', async () => {
+    expect.assertions(1)
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            path: '/',
+          },
+          actions: {
+            navigate({ state }) {
+              state.path = '/new'
+            },
+          },
+        },
+      })
+    )
+    await app.initialized
+
+    app.eventHub.once(EventType.MUTATIONS, (data) => {
+      expect(toJSON(data)).toEqual({
+        actionId: 'router.navigate',
+        isRunning: true,
+        actionName: 'router.navigate',
+        mutations: [
+          {
+            args: ['/new'],
+            method: 'set',
+            path: 'router.path',
+            hasChangedValue: true,
+            delimiter: '.',
+          },
+        ],
+        executionId: expect.any(Number),
+        operatorId: 0,
+        namespacePath: ['router'],
+        path: [],
+        type: 'action',
+      })
+    })
+
+    app.actions.router.navigate()
+  })
+
+  test('should work with multiple levels of namespacing', () => {
+    const app = new Overmind(
+      namespaced({
+        modules: merge(
+          { state: {} },
+          namespaced({
+            router: {
+              state: {
+                path: '/',
+              },
+              actions: {
+                navigate({ state }) {
+                  state.path = '/nested'
+                },
+              },
+            },
+          })
+        ),
+      })
+    )
+
+    expect((app.state as any).modules.router.path).toBe('/')
+    ;(app.actions as any).modules.router.navigate()
+    expect((app.state as any).modules.router.path).toBe('/nested')
+  })
+
+  test('should not break non-namespaced actions', () => {
+    const app = new Overmind({
+      state: {
+        count: 0,
+      },
+      actions: {
+        increment({ state }) {
+          state.count++
+        },
+      },
+    })
+
+    expect(app.state.count).toBe(0)
+    app.actions.increment()
+    expect(app.state.count).toBe(1)
+  })
+
+  test('should work with mixed namespaced and non-namespaced config', () => {
+    const app = new Overmind(
+      merge(
+        {
+          state: {
+            global: 'value',
+          },
+          actions: {
+            changeGlobal({ state }) {
+              state.global = 'changed'
+            },
+          },
+        },
+        namespaced({
+          router: {
+            state: {
+              path: '/',
+            },
+            actions: {
+              navigate({ state, actions }) {
+                state.path = '/new'
+                ;(actions as any).changeGlobal()
+              },
+            },
+          },
+        })
+      )
+    )
+
+    app.actions.router.navigate()
+    expect(app.state.router.path).toBe('/new')
+    expect(app.state.global).toBe('changed')
+  })
+
+  test('should handle effects being called with parameters', () => {
+    const app = new Overmind(
+      namespaced({
+        router: {
+          state: {
+            result: '',
+          },
+          effects: {
+            buildUrl(base: string, path: string) {
+              return `${base}${path}`
+            },
+          },
+          actions: {
+            navigate({ state, effects }, path: string) {
+              state.result = effects.buildUrl('https://example.com', path)
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.router.navigate('/about')
+    expect(app.state.router.result).toBe('https://example.com/about')
+  })
+
+  test('should preserve module isolation when multiple modules access same effect name', () => {
+    const app = new Overmind(
+      namespaced({
+        moduleA: {
+          state: {
+            value: '',
+          },
+          effects: {
+            getValue() {
+              return 'A'
+            },
+          },
+          actions: {
+            update({ state, effects }) {
+              state.value = effects.getValue()
+            },
+          },
+        },
+        moduleB: {
+          state: {
+            value: '',
+          },
+          effects: {
+            getValue() {
+              return 'B'
+            },
+          },
+          actions: {
+            update({ state, effects }) {
+              state.value = effects.getValue()
+            },
+          },
+        },
+      })
+    )
+
+    app.actions.moduleA.update()
+    app.actions.moduleB.update()
+    expect(app.state.moduleA.value).toBe('A')
+    expect(app.state.moduleB.value).toBe('B')
+  })
+})
+
+describe('Namespaced module scoping with statemachines', () => {
+  test('should allow statemachine to work in namespaced module', () => {
+    type States =
+      | {
+          current: 'IDLE'
+        }
+      | {
+          current: 'LOADING'
+        }
+      | {
+          current: 'LOADED'
+          data: string
+        }
+
+    type Events =
+      | { type: 'START_LOAD' }
+      | { type: 'LOAD_SUCCESS'; data: string }
+      | { type: 'RESET' }
+
+    const machine = statemachine<States, Events>({
+      IDLE: {
+        START_LOAD: () => ({ current: 'LOADING' }),
+      },
+      LOADING: {
+        LOAD_SUCCESS: (data) => ({ current: 'LOADED', data }),
+        RESET: () => ({ current: 'IDLE' }),
+      },
+      LOADED: {
+        RESET: () => ({ current: 'IDLE' }),
+      },
+    })
+
+    const app = createOvermind(
+      namespaced({
+        router: {
+          state: machine.create({ current: 'IDLE' }),
+          actions: {
+            startLoad({ state }) {
+              state.send('START_LOAD')
+            },
+            loadSuccess({ state }, data: string) {
+              state.send('LOAD_SUCCESS', data)
+            },
+            reset({ state }) {
+              state.send('RESET')
+            },
+          },
+        },
+      })
+    )
+
+    // Initial state
+    expect(app.state.router.current).toBe('IDLE')
+
+    // Transition to loading
+    app.actions.router.startLoad()
+    expect(app.state.router.current).toBe('LOADING')
+
+    // Transition to loaded
+    app.actions.router.loadSuccess('test data')
+    expect(app.state.router.current).toBe('LOADED')
+    expect((app.state.router as any).data).toBe('test data')
+
+    // Reset
+    app.actions.router.reset()
+    expect(app.state.router.current).toBe('IDLE')
+  })
+
+  test('should allow statemachine with baseState in namespaced module', () => {
+    type States =
+      | {
+          current: 'OFF'
+        }
+      | {
+          current: 'ON'
+          brightness: number
+        }
+
+    type Events = { type: 'TOGGLE' } | { type: 'SET_BRIGHTNESS'; data: number }
+
+    type BaseState = {
+      name: string
+    }
+
+    const machine = statemachine<States, Events, BaseState>({
+      OFF: {
+        TOGGLE: () => ({
+          current: 'ON',
+          brightness: 50,
+        }),
+      },
+      ON: {
+        TOGGLE: () => ({ current: 'OFF' }),
+        SET_BRIGHTNESS: (brightness) => ({ current: 'ON', brightness }),
+      },
+    })
+
+    const app = createOvermind(
+      namespaced({
+        device: {
+          state: machine.create({ current: 'OFF' }, { name: 'Light' }),
+          actions: {
+            toggle({ state }) {
+              state.send('TOGGLE')
+            },
+            setBrightness({ state }, brightness: number) {
+              state.send('SET_BRIGHTNESS', brightness)
+            },
+          },
+        },
+      })
+    )
+
+    // Check baseState is accessible
+    expect((app.state.device as any).name).toBe('Light')
+    expect(app.state.device.current).toBe('OFF')
+
+    // Toggle on
+    app.actions.device.toggle()
+    expect(app.state.device.current).toBe('ON')
+    expect((app.state.device as any).brightness).toBe(50)
+
+    // Set brightness
+    app.actions.device.setBrightness(75)
+    expect((app.state.device as any).brightness).toBe(75)
+    expect((app.state.device as any).name).toBe('Light')
+
+    // Toggle off
+    app.actions.device.toggle()
+    expect(app.state.device.current).toBe('OFF')
+  })
+
+  test('should allow using matches() in namespaced module', () => {
+    type States = { current: 'IDLE' } | { current: 'ACTIVE' }
+
+    type Events = { type: 'ACTIVATE' } | { type: 'DEACTIVATE' }
+
+    const machine = statemachine<States, Events>({
+      IDLE: {
+        ACTIVATE: () => ({ current: 'ACTIVE' }),
+      },
+      ACTIVE: {
+        DEACTIVATE: () => ({ current: 'IDLE' }),
+      },
+    })
+
+    const app = createOvermind(
+      namespaced({
+        module: {
+          state: machine.create({ current: 'IDLE' }),
+          actions: {
+            checkIdle({ state }) {
+              return !!state.matches('IDLE')
+            },
+            checkActive({ state }) {
+              return !!state.matches('ACTIVE')
+            },
+            activate({ state }) {
+              state.send('ACTIVATE')
+            },
+          },
+        },
+      })
+    )
+
+    expect(app.actions.module.checkIdle()).toBe(true)
+    expect(app.actions.module.checkActive()).toBe(false)
+
+    app.actions.module.activate()
+
+    expect(app.actions.module.checkIdle()).toBe(false)
+    expect(app.actions.module.checkActive()).toBe(true)
+  })
+
+  test('should transition statemachine in namespaced module using function', () => {
+    type States = { current: 'FOO' } | { current: 'BAR' }
+
+    type Events = { type: 'TOGGLE' }
+
+    const machine = statemachine<States, Events>((_, state) => {
+      return { current: state.current === 'FOO' ? 'BAR' : 'FOO' }
+    })
+
+    const app = createOvermind(
+      namespaced({
+        test: {
+          state: machine.create({ current: 'FOO' }),
+          actions: {
+            toggle({ state }) {
+              state.send('TOGGLE')
+            },
+          },
+        },
+      })
+    )
+
+    expect(app.state.test.current).toBe('FOO')
+    app.actions.test.toggle()
+    expect(app.state.test.current).toBe('BAR')
+    app.actions.test.toggle()
+    expect(app.state.test.current).toBe('FOO')
+  })
+
+  test('should work with StateMachine in a real app structure', async () => {
+    type RouterStates =
+      | { current: 'IDLE' }
+      | { current: 'NAVIGATING'; path: string }
+
+    type RouterEvents =
+      | { type: 'NAVIGATE'; data: string }
+      | { type: 'COMPLETE' }
+
+    const routerMachine = statemachine<RouterStates, RouterEvents>({
+      IDLE: {
+        NAVIGATE: (path) => ({ current: 'NAVIGATING', path }),
+      },
+      NAVIGATING: {
+        COMPLETE: () => ({ current: 'IDLE' }),
+      },
+    })
+
+    type AppStates = { current: 'READY' }
+    type AppEvents = { type: 'INIT' }
+
+    const appMachine = statemachine<AppStates, AppEvents>({
+      READY: {},
+    })
+
+    const app = createOvermind(
+      namespaced({
+        app: {
+          state: appMachine.create({ current: 'READY' }),
+        },
+        router: {
+          state: routerMachine.create({ current: 'IDLE' }),
+          actions: {
+            navigate({ state }, path: string) {
+              state.send('NAVIGATE', path)
+            },
+            complete({ state }) {
+              state.send('COMPLETE')
+            },
+          },
+        },
+      })
+    )
+
+    await app.initialized
+
+    expect(app.state.router.current).toBe('IDLE')
+    app.actions.router.navigate('/test')
+    expect(app.state.router.current).toBe('NAVIGATING')
+    expect((app.state.router as any).path).toBe('/test')
   })
 })

--- a/packages/overmind/src/index.ts
+++ b/packages/overmind/src/index.ts
@@ -15,7 +15,11 @@ export type {
 export { createOperator, createMutationOperator } from './operator'
 export { MODE_DEFAULT, MODE_TEST, MODE_SSR, ENVIRONMENT, json } from './utils'
 export { SERIALIZE, rehydrate } from './rehydrate'
-export { type Statemachine, statemachine } from './statemachine'
+export {
+  type MachineMethods,
+  type Statemachine,
+  statemachine,
+} from './statemachine'
 export * from './OvermindMock'
 export * from './OvermindSSR'
 

--- a/packages/overmind/src/statemachine.ts
+++ b/packages/overmind/src/statemachine.ts
@@ -3,6 +3,7 @@ import { IMutationTree, PATH, PROXY_TREE, VALUE } from 'proxy-state-tree'
 
 import { IState } from '.'
 import { Devtools } from './Devtools'
+import { isStateMachine } from './utils'
 
 type TState = {
   current: string
@@ -79,7 +80,7 @@ const TRANSITION_LISTENERS = Symbol('TRANSITION_LISTENERS')
 
 // We have to export here to avoid a circular dependency issue with "utils"
 export function deepCopy(obj) {
-  if (obj instanceof StateMachine) {
+  if (isStateMachine(obj)) {
     return (obj as any).clone()
   } else if (isPlainObject(obj)) {
     return Object.keys(obj).reduce((aggr: any, key) => {

--- a/packages/overmind/src/utils.ts
+++ b/packages/overmind/src/utils.ts
@@ -1,6 +1,6 @@
 import isPlainObject from 'is-plain-obj'
 import { IMutation, IS_PROXY, VALUE } from 'proxy-state-tree'
-import { deepCopy } from './statemachine'
+import { deepCopy, StateMachine } from './statemachine'
 
 // Due to avoid circular dependency warnings we export this utility from here
 export { deepCopy } from './statemachine'
@@ -250,4 +250,8 @@ function hasStateChartStructure(state: any): boolean {
     state.actions &&
     typeof state.actions === 'object'
   )
+}
+
+export const isStateMachine = (obj: any): boolean => {
+  return obj instanceof StateMachine
 }


### PR DESCRIPTION
### Problem
When creating reusable Overmind modules (like `overmind-router`), actions within a namespaced module needed to explicitly reference their namespace when accessing state, effects, or other actions. For example:

```typescript
// overmind-router internal code had to use namespaced paths
export const navigate = ({ state, effects }) => {
  const baseUrl = effects.router.getBaseUrl()  // ❌ Requires knowing namespace
  state.router.currentPath = '/new'             // ❌ Not self-contained
}
```

This made modules:
- Not truly self-contained or reusable
- Tightly coupled to their namespace name
- Difficult to test in isolation
- Fragile when namespace structure changes

### Solution
Introduced automatic context scoping through a `createScopedProxy` method that wraps the context provided to namespaced module actions. When an action from a namespaced module executes, it receives scoped access where property lookups automatically resolve to the module's namespace first, then fall back to root.

```typescript
// Now modules can be written without namespace knowledge
export const navigate = ({ state, effects }) => {
  const baseUrl = effects.getBaseUrl()  // ✅ Automatically scoped to router namespace
  state.currentPath = '/new'            // ✅ Self-contained
}
```

### Implementation Details
- **Scoped proxy creation**: Added `createScopedProxy` method that creates a Proxy intercepting property access
- **Namespace-aware context**: Modified `createContext` to provide scoped proxies when `execution.namespacePath` exists
- **StateMachine support**: Properly bind methods to preserve `this` context across module boundaries
- **Fallback behavior**: Maintains access to root-level shared resources (effects, cross-module state)
- **Zero breaking changes**: Non-namespaced modules work exactly as before

### Benefits
- ✅ Truly portable, self-contained modules
- ✅ No namespace configuration needed inside of the module
- ✅ Cleaner, more maintainable module code
- ✅ Better separation of concerns
- ✅ Backwards compatible with existing code
- ✅ Works with StateMachines, lazy-loaded modules, and all existing features

### Testing
- Added comprehensive test suite for namespaced module scoping
- Verified StateMachine integration
- Tested cross-module communication and shared effects
- Validated backwards compatibility with non-namespaced code