### PR TITLE
Move state transformation from proxy wrapper to proxy-state-tree hook

### DIFF
--- a/packages/overmind/src/Overmind.ts
+++ b/packages/overmind/src/Overmind.ts
@@ -248,6 +248,12 @@ export class Overmind<
     }
   }
 
+  private currentExecution: internalTypes.Execution | null = null
+
+  private getCurrentExecution() {
+    return this.currentExecution
+  }
+
   private createProxyStateTree(
     configuration: IConfiguration,
     eventHub: EventEmitter<any> | utils.MockedEventEmitter,
@@ -260,6 +266,34 @@ export class Overmind<
         devmode: devmode && !ssr,
         ssr,
         delimiter: this.delimiter,
+        transformPath: (path: string) => {
+          const execution = this.getCurrentExecution()
+          if (!execution?.namespacePath?.length) {
+            return path // No namespace, no transformation
+          }
+
+          if (!path) {
+            return path
+          }
+
+          const pathSegments = path.split(this.delimiter)
+          const firstSegment = pathSegments[0]
+
+          // Get root level keys to detect absolute paths
+          const rootKeys =
+            this.state && typeof this.state === 'object'
+              ? Object.keys(this.state)
+              : []
+
+          // Absolute paths start with a root key - don't transform
+          if (rootKeys.includes(firstSegment)) {
+            return path
+          }
+
+          // Relative path - prepend namespace
+          const namespace = execution.namespacePath.join(this.delimiter)
+          return namespace + this.delimiter + path
+        },
         onSetFunction: (tree, path, target, prop, func) => {
           if (func[IS_DERIVED_CONSTRUCTOR]) {
             return new Derived(func) as any
@@ -397,7 +431,7 @@ export class Overmind<
           obj
         )
 
-        // Special handling for StateMachine: bind methods to preserve context
+        // If the entire namespace is a StateMachine
         if (utils.isStateMachine(namespaceObj)) {
           if (prop in namespaceObj) {
             const value = namespaceObj[prop]
@@ -413,12 +447,11 @@ export class Overmind<
           return obj[prop]
         }
 
-        // Standard scoping: prefer namespace, fallback to root
+        // Standard scoping for actions/effects
         const value =
           namespaceObj && prop in namespaceObj ? namespaceObj[prop] : obj[prop]
 
-        // If we got a function from the namespace object (like an effect method),
-        // bind it to maintain the correct 'this' context
+        // Bind functions to maintain correct 'this' context
         if (
           namespaceObj &&
           prop in namespaceObj &&
@@ -428,20 +461,6 @@ export class Overmind<
         }
 
         return value
-      },
-
-      set: (obj, prop, value) => {
-        const namespaceObj = namespacePath.reduce(
-          (aggr, key) => aggr?.[key],
-          obj
-        )
-
-        if (namespaceObj) {
-          namespaceObj[prop] = value
-        } else {
-          obj[prop] = value
-        }
-        return true
       },
 
       has: (obj, prop) => {
@@ -500,9 +519,7 @@ export class Overmind<
     })
 
     return {
-      state: namespacePath.length
-        ? this.createScopedProxy(tree.state, namespacePath)
-        : tree.state,
+      state: tree.state,
       actions: namespacePath.length
         ? this.createScopedProxy(actionsProxy, namespacePath)
         : actionsProxy,
@@ -569,8 +586,6 @@ export class Overmind<
     this.actionReferences[name] = originalAction
     const actionFunc = (value?, boundExecution?: internalTypes.Execution) => {
       const action = this.actionReferences[name]
-      // Developer might unintentionally pass more arguments, so have to ensure
-      // that it is an actual execution
       boundExecution =
         boundExecution && boundExecution[utils.EXECUTION]
           ? boundExecution
@@ -582,46 +597,58 @@ export class Overmind<
         this.mode.mode === utils.MODE_SSR
       ) {
         const execution = this.createExecution(name, action, boundExecution)
-        this.eventHub.emit(internalTypes.EventType.ACTION_START, {
-          ...execution,
-          value,
-        })
 
-        if (action[utils.IS_OPERATOR]) {
-          return new Promise((resolve, reject) => {
-            action(
-              null,
-              {
-                ...this.createContext(execution, this.proxyStateTreeInstance),
-                value,
-              },
-              (err, finalContext) => {
-                execution.isRunning = false
-                finalContext &&
-                  this.eventHub.emit(internalTypes.EventType.ACTION_END, {
-                    ...finalContext.execution,
-                    operatorId: finalContext.execution.operatorId - 1,
-                  })
-                if (err) reject(err)
-                else {
-                  resolve(finalContext.value)
-                }
-              }
-            )
+        const previousExecution = this.currentExecution
+        this.currentExecution = execution
+
+        try {
+          this.eventHub.emit(internalTypes.EventType.ACTION_START, {
+            ...execution,
+            value,
           })
-        } else {
-          const mutationTree = execution.getMutationTree()
-          if (this.isStrict) {
-            mutationTree.blockMutations()
+
+          if (action[utils.IS_OPERATOR]) {
+            return new Promise((resolve, reject) => {
+              action(
+                null,
+                {
+                  ...this.createContext(execution, this.proxyStateTreeInstance),
+                  value,
+                },
+                (err, finalContext) => {
+                  execution.isRunning = false
+                  finalContext &&
+                    this.eventHub.emit(internalTypes.EventType.ACTION_END, {
+                      ...finalContext.execution,
+                      operatorId: finalContext.execution.operatorId - 1,
+                    })
+                  if (err) reject(err)
+                  else {
+                    resolve(finalContext.value)
+                  }
+                }
+              )
+            }).finally(() => {
+              this.currentExecution = previousExecution
+            })
+          } else {
+            const mutationTree = execution.getMutationTree()
+            if (this.isStrict) {
+              mutationTree.blockMutations()
+            }
+            const returnValue = action(
+              this.createContext(execution, mutationTree),
+              value
+            )
+
+            this.eventHub.emit(internalTypes.EventType.ACTION_END, execution)
+
+            return returnValue
           }
-          const returnValue = action(
-            this.createContext(execution, mutationTree),
-            value
-          )
-
-          this.eventHub.emit(internalTypes.EventType.ACTION_END, execution)
-
-          return returnValue
+        } finally {
+          if (!action[utils.IS_OPERATOR]) {
+            this.currentExecution = previousExecution
+          }
         }
       } else {
         const execution = {
@@ -629,6 +656,10 @@ export class Overmind<
           operatorId: 0,
           type: 'action',
         }
+
+        const previousExecution = this.currentExecution
+        this.currentExecution = execution
+
         this.eventHub.emit(internalTypes.EventType.ACTION_START, {
           ...execution,
           value,
@@ -648,6 +679,9 @@ export class Overmind<
 
         const scopedValue = this.scopeValue(value, mutationTree)
         const context = this.createContext(execution, mutationTree)
+
+        let result
+        let isAsync = false
 
         try {
           let pendingFlush
@@ -677,9 +711,10 @@ export class Overmind<
             }
           })
 
-          let result = action(context, scopedValue)
+          result = action(context, scopedValue)
+          isAsync = utils.isPromise(result)
 
-          if (utils.isPromise(result)) {
+          if (isAsync) {
             this.eventHub.emit(
               internalTypes.EventType.OPERATOR_ASYNC,
               execution
@@ -720,6 +755,9 @@ export class Overmind<
 
                 throw error
               })
+              .finally(() => {
+                this.currentExecution = previousExecution
+              })
           } else {
             execution.isRunning = false
             if (!boundExecution) {
@@ -743,6 +781,10 @@ export class Overmind<
           })
           this.eventHub.emit(internalTypes.EventType.ACTION_END, execution)
           throw err
+        } finally {
+          if (!isAsync) {
+            this.currentExecution = previousExecution
+          }
         }
       }
     }

--- a/packages/overmind/src/index.test.ts
+++ b/packages/overmind/src/index.test.ts
@@ -911,6 +911,33 @@ describe('Namespaced module scoping', () => {
     expect(app.state.moduleA.value).toBe('A')
     expect(app.state.moduleB.value).toBe('B')
   })
+
+  test('should replace namespace object when action assigns the namespace key (no nested duplication)', () => {
+    const app = new Overmind({
+      state: {
+        user: {
+          status: 'logged_in',
+        },
+      },
+      actions: {
+        user: {
+          logout({ state }: any) {
+            ;(state as any)._probe = 'probe'
+            state.user = { status: 'logged_out' }
+          },
+        },
+      },
+    })
+
+    // Initial state
+    expect(app.state.user.status).toBe('logged_in')
+    // Execute logout which replaces the whole namespace object
+    app.actions.user.logout()
+    // Ensure the whole namespace object was replaced, not nested under itself
+    expect(app.state.user.status).toBe('logged_out')
+    // Ensure we didn't accidentally merge or create nested user.user
+    expect((app.state as any).user.user).toBeUndefined()
+  })
 })
 
 describe('Namespaced module scoping with statemachines', () => {

--- a/packages/overmind/src/internalTypes.ts
+++ b/packages/overmind/src/internalTypes.ts
@@ -75,6 +75,7 @@ export type Execution = {
   isRunning: boolean
   parentExecution?: Execution
   path: string[]
+  namespacePath?: string[]
   emit(event: EventType, value: any): void
   flush(isAsync?: boolean): {
     mutations: IMutation[]

--- a/packages/proxy-state-tree/src/Proxyfier.ts
+++ b/packages/proxy-state-tree/src/Proxyfier.ts
@@ -253,6 +253,44 @@ export class Proxifier {
     return proxy
   }
 
+  private resolveTransformedPath(
+    path: string,
+    target: any,
+    prop: string | symbol
+  ) {
+    const originalPath = this.concat(path, prop)
+    let transformedPath = originalPath
+
+    // Apply path transformation if configured
+    if (this.tree.root.options.transformPath) {
+      transformedPath = this.tree.root.options.transformPath(originalPath)
+    }
+
+    // If no transformation occurred, return early
+    if (transformedPath === originalPath) {
+      return {
+        nestedPath: originalPath,
+        actualTarget: target,
+        actualProp: prop,
+        wasTransformed: false,
+      }
+    }
+
+    // Navigate to transformed location
+    const segments = transformedPath.split(this.delimiter)
+    const actualProp = segments[segments.length - 1]
+    const actualTarget = segments
+      .slice(0, -1)
+      .reduce((obj, key) => obj?.[key], target)
+
+    return {
+      nestedPath: transformedPath,
+      actualTarget: actualTarget || target,
+      actualProp,
+      wasTransformed: true,
+    }
+  }
+
   private createObjectProxy(object, path) {
     if (!this.ssr && this.isProxyCached(object, path)) {
       return object[this.CACHED_PROXY]
@@ -295,36 +333,56 @@ export class Proxifier {
         }
 
         const trackingTree = proxifier.getTrackingTree()
-
-        const targetValue = target[prop]
-        const nestedPath = proxifier.concat(path, prop)
         const currentTree = trackingTree || proxifier.tree
 
-        if (typeof targetValue === 'function') {
+        const { nestedPath, actualTarget, actualProp, wasTransformed } =
+          proxifier.resolveTransformedPath(path, target, prop)
+
+        const actualValue = actualTarget[actualProp]
+
+        if (typeof actualValue === 'function') {
           if (proxifier.tree.root.options.onGetFunction) {
-            return proxifier.tree.root.options.onGetFunction(
+            const result = proxifier.tree.root.options.onGetFunction(
               trackingTree || proxifier.tree,
               nestedPath,
-              target,
-              prop
+              actualTarget,
+              actualProp
             )
+
+            // If onGetFunction handled it, use that result
+            if (result !== actualValue) {
+              return result
+            }
           }
-          return isClass(target)
-            ? targetValue
-            : targetValue.call(target, proxifier.tree, nestedPath)
+
+          // Handle binding for transformed paths (namespace scoping)
+          if (wasTransformed && isClass(actualTarget)) {
+            const targetPath = nestedPath.substring(
+              0,
+              nestedPath.lastIndexOf(proxifier.delimiter)
+            )
+            const proxiedTarget = proxifier.proxify(actualTarget, targetPath)
+            return actualValue.bind(proxiedTarget)
+          }
+
+          // Default behavior for functions
+          return isClass(actualTarget)
+            ? actualValue
+            : actualValue.call(actualTarget, proxifier.tree, nestedPath)
         } else {
           currentTree.trackPathListeners.forEach((cb) => cb(nestedPath))
           trackingTree && trackingTree.proxifier.trackPath(nestedPath)
         }
 
-        if (shouldProxy(targetValue)) {
-          return proxifier.proxify(targetValue, nestedPath)
+        if (shouldProxy(actualValue)) {
+          return proxifier.proxify(actualValue, nestedPath)
         }
 
-        return targetValue
+        return actualValue
       },
       set(target, prop, value) {
-        const nestedPath = proxifier.concat(path, prop)
+        const { nestedPath, actualTarget, actualProp } =
+          proxifier.resolveTransformedPath(path, target, prop)
 
         /* @__PURE__ */ proxifier.ensureMutationTrackingIsEnabled(nestedPath)
         /* @__PURE__ */ proxifier.ensureValueDosntExistInStateTreeElsewhere(
@@ -333,12 +391,12 @@ export class Proxifier {
 
         let objectChangePath
 
-        if (!(prop in target)) {
+        if (!(actualProp in actualTarget)) {
           objectChangePath = path
         }
 
         const mutationTree = proxifier.getMutationTree()
-        const existingValue = target[prop]
+        const existingValue = actualTarget[actualProp]
 
         if (
           typeof value === 'function' &&
@@ -347,14 +405,14 @@ export class Proxifier {
           value = proxifier.tree.root.options.onSetFunction(
             proxifier.getTrackingTree() || proxifier.tree,
             nestedPath,
-            target,
-            prop,
+            actualTarget,
+            actualProp,
             value
           )
         }
 
         const hasChangedValue = existingValue !== value
-        const result = Reflect.set(target, prop, value)
+        const result = Reflect.set(actualTarget, actualProp, value)
 
         mutationTree.addMutation(
           {
@@ -370,18 +428,19 @@ export class Proxifier {
         return result
       },
       deleteProperty(target, prop) {
-        const nestedPath = proxifier.concat(path, prop)
+        const { nestedPath, actualTarget, actualProp } =
+          proxifier.resolveTransformedPath(path, target, prop)
 
         /* @__PURE__ */ proxifier.ensureMutationTrackingIsEnabled(nestedPath)
 
         let objectChangePath
-        if (prop in target) {
+        if (actualProp in actualTarget) {
           objectChangePath = path
         }
 
         const mutationTree = proxifier.getMutationTree()
 
-        delete target[prop]
+        delete actualTarget[actualProp]
 
         mutationTree.addMutation(
           {

--- a/packages/proxy-state-tree/src/types.ts
+++ b/packages/proxy-state-tree/src/types.ts
@@ -76,6 +76,7 @@ export interface IOptions<D> {
   onGetFunction?: (...args: any[]) => any
   onGetter?: Function
   getDevtools?: () => D
+  transformPath?: (path: string) => string
 }
 
 export interface IFlushCallback {


### PR DESCRIPTION
Fixes #638 by reimplementing namespace scoping at a lower level within
proxy-state-tree instead of wrapping state with an additional proxy layer.

The initial implementation used createScopedProxy which worked for actions
and effects but caused incorrect nested state mutations due to adding an
extra proxy layer on top of proxy-state-tree's existing proxies.

Changes in proxy-state-tree:
- Added transformPath hook to IOptions interface for path transformation
- Implemented resolveTransformedPath() in Proxifier to resolve transformed paths
- Modified createObjectProxy to apply transformations during property access
- Ensured proper method binding for transformed class instances (StateMachine)

Changes in Overmind:
- Removed createScopedProxy for state (kept for actions/effects)
- Implemented transformPath option in createProxyStateTree configuration
- Added execution context tracking to provide namespace information to transformPath
- Modified createAction to track currentExecution for async actions

This approach eliminates the extra proxy layer while maintaining namespace
scoping functionality, allowing state.user.status mutations to work correctly
in namespaced modules.