### PR TITLE
bug fix: `pipe`/`branch` operators re-invoke on error instead of propagating it

### DIFF
--- a/packages/overmind/src/operators.test.ts
+++ b/packages/overmind/src/operators.test.ts
@@ -14,6 +14,7 @@ import {
   waitUntil,
   IContext,
 } from './'
+import { IS_OPERATOR } from './utils'
 
 describe('OPERATORS', () => {
   test('branch - passes input as output', async () => {
@@ -513,5 +514,79 @@ describe('OPERATORS', () => {
     return overmind.actions.test().then(() => {
       expect(overmind.state.runCount).toBe(1)
     })
+  })
+
+  test('pipe - propagates error from throwing IS_OPERATOR instead of re-invoking', async () => {
+    let callCount = 0
+    const throwingOperator: any = (_err: any, _context: any, _next: any) => {
+      callCount++
+      throw new Error('sync throw')
+    }
+    throwingOperator[IS_OPERATOR] = true
+
+    const state = {
+      error: '',
+    }
+
+    const test = (pipe as any)(
+      throwingOperator,
+      catchError(({ state }: any, error: Error) => {
+        state.error = error.message
+        return 'caught'
+      })
+    )
+
+    const actions = { test }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const overmind = new Overmind(config) as any
+
+    await overmind.actions.test()
+
+    expect(callCount).toBe(1)
+    expect(overmind.state.error).toBe('sync throw')
+  })
+
+  test('branch - propagates error from throwing IS_OPERATOR instead of re-invoking', async () => {
+    let callCount = 0
+    const throwingOperator: any = (_err: any, _context: any, _next: any) => {
+      callCount++
+      throw new Error('sync throw')
+    }
+    throwingOperator[IS_OPERATOR] = true
+
+    const state = {
+      error: '',
+      value: '',
+    }
+
+    const test = (pipe as any)(
+      (branch as any)(throwingOperator),
+      catchError(({ state }: any, error: Error) => {
+        state.error = error.message
+        return 'caught'
+      }),
+      ({ state }: any, value: string) => {
+        state.value = value
+      }
+    )
+
+    const actions = { test }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const overmind = new Overmind(config) as any
+
+    await overmind.actions.test()
+
+    expect(callCount).toBe(1)
+    expect(overmind.state.error).toBe('sync throw')
   })
 })

--- a/packages/overmind/src/operators.ts
+++ b/packages/overmind/src/operators.ts
@@ -102,7 +102,7 @@ export function pipe(...operators: any[]) {
         try {
           operatorToRun(operatorErr, operatorContext, run, final)
         } catch (operatorError) {
-          operatorToRun(operatorErr, operatorContext, run, final)
+          run(operatorError, operatorContext)
         }
       }
 
@@ -214,7 +214,7 @@ export function branch(...operators: any[]) {
         try {
           operatorToRun(operatorErr, operatorContext, run, final)
         } catch (operatorError) {
-          operatorToRun(operatorErr, operatorContext, run, final)
+          run(operatorError, operatorContext)
         }
       }
 


### PR DESCRIPTION
The bug was in packages/overmind/src/operators.ts in both pipe (line 105) and branch (line 217). The catch blocks were re-invoking the same operator that just    
  threw:                                                    

  // Before (bug): re-invokes the throwing operator → infinite recursion
  catch (operatorError) {
    operatorToRun(operatorErr, operatorContext, run, final)
  }

  // After (fix): propagates the error to the next operator in the chain
  catch (operatorError) {
    run(operatorError, operatorContext)
  }

  By calling run(operatorError, operatorContext), the error is passed forward through the operator chain where it can be handled by catchError or tryCatch —
  matching how createOperator and createMutationOperator already handle errors internally.