### PR TITLE
fix(statechart, overmind): await async exit actions, fix devtools actions, fix throttle stale value

### DIFF
--- a/packages/overmind-statechart/src/index.test.ts
+++ b/packages/overmind-statechart/src/index.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { IContext, createOvermind } from 'overmind'
+import { IContext, createOvermind, pipe, wait } from 'overmind'
 
 import { Statechart, statechart } from './'
 
@@ -1080,5 +1080,314 @@ describe('Statecharts', () => {
       'entry',
       'step2',
     ])
+  })
+
+  test('should work with operator-based action using pipe', async () => {
+    const increaseCount = pipe(function step({ state }: any) {
+      state.count++
+    })
+
+    const state = {
+      count: 0,
+    }
+    const actions = {
+      increaseCount,
+    }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const chart: Statechart<
+      typeof config,
+      {
+        foo: void
+        bar: void
+      }
+    > = {
+      initial: 'foo',
+      states: {
+        foo: {
+          on: {
+            increaseCount: 'bar',
+          },
+        },
+        bar: {},
+      },
+    }
+
+    const instance = createOvermind(
+      statechart(config, {
+        id1: chart,
+      })
+    )
+
+    expect(instance.state.states).toEqual([['id1', 'foo']])
+    expect(instance.state.actions).toEqual({ increaseCount: true })
+
+    await instance.actions.increaseCount()
+
+    expect(instance.state.states).toEqual([['id1', 'bar']])
+    expect(instance.state.actions).toEqual({ increaseCount: false })
+    expect(instance.state.count).toBe(1)
+  })
+
+  test('should work with multi-step operator pipe action', async () => {
+    const doTransition = pipe(
+      function addFirst({ state }: any) {
+        state.steps.push('first')
+      },
+      function addSecond({ state }: any) {
+        state.steps.push('second')
+      }
+    )
+
+    const state = {
+      steps: [] as string[],
+    }
+    const actions = {
+      doTransition,
+    }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const chart: Statechart<
+      typeof config,
+      {
+        foo: void
+        bar: void
+      }
+    > = {
+      initial: 'foo',
+      states: {
+        foo: {
+          on: {
+            doTransition: 'bar',
+          },
+        },
+        bar: {},
+      },
+    }
+
+    const instance = createOvermind(
+      statechart(config, {
+        id1: chart,
+      })
+    )
+
+    await instance.actions.doTransition()
+
+    expect(instance.state.states).toEqual([['id1', 'bar']])
+    expect(instance.state.steps).toEqual(['first', 'second'])
+  })
+
+  test('should await operator-based exit action with async steps before main action', async () => {
+    const exitAction = pipe(wait(50), function onExit({ state }: any) {
+      state.events.push('exit')
+    })
+
+    const doTransition = pipe(function step({ state }: any) {
+      state.events.push('main')
+    })
+
+    const state = {
+      events: [] as string[],
+    }
+    const actions = {
+      exitAction,
+      doTransition,
+    }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const chart: Statechart<
+      typeof config,
+      {
+        foo: void
+        bar: void
+      }
+    > = {
+      initial: 'foo',
+      states: {
+        foo: {
+          exit: 'exitAction',
+          on: {
+            doTransition: 'bar',
+          },
+        },
+        bar: {},
+      },
+    }
+
+    const instance = createOvermind(
+      statechart(config, {
+        id1: chart,
+      })
+    )
+
+    await instance.actions.doTransition()
+
+    expect(instance.state.states).toEqual([['id1', 'bar']])
+    expect(instance.state.events).toEqual(['exit', 'main'])
+  })
+
+  test('should block operator-based action not allowed by statechart', async () => {
+    const increaseCount = pipe(function step({ state }: any) {
+      state.count++
+    })
+
+    const state = {
+      count: 0,
+    }
+    const actions = {
+      increaseCount,
+    }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const chart: Statechart<
+      typeof config,
+      {
+        foo: void
+        bar: void
+      }
+    > = {
+      initial: 'foo',
+      states: {
+        foo: {},
+        bar: {
+          on: {
+            increaseCount: null,
+          },
+        },
+      },
+    }
+
+    const instance = createOvermind(
+      statechart(config, {
+        id1: chart,
+      })
+    )
+
+    expect(instance.state.actions).toEqual({ increaseCount: false })
+
+    await instance.actions.increaseCount()
+
+    expect(instance.state.count).toBe(0)
+  })
+
+  test('should work with operator-based action without transition target', async () => {
+    const increaseCount = pipe(function step({ state }: any) {
+      state.count++
+    })
+
+    const state = {
+      count: 0,
+    }
+    const actions = {
+      increaseCount,
+    }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const chart: Statechart<
+      typeof config,
+      {
+        foo: void
+      }
+    > = {
+      initial: 'foo',
+      states: {
+        foo: {
+          on: {
+            increaseCount: null,
+          },
+        },
+      },
+    }
+
+    const instance = createOvermind(
+      statechart(config, {
+        id1: chart,
+      })
+    )
+
+    expect(instance.state.actions).toEqual({ increaseCount: true })
+
+    await instance.actions.increaseCount()
+
+    expect(instance.state.states).toEqual([['id1', 'foo']])
+    expect(instance.state.count).toBe(1)
+  })
+
+  test('should complete async exit action then execute transition', async () => {
+    // Verifies that async exit actions fully complete before the
+    // main action and transition execute
+    const exitAction = async ({ state }: any) => {
+      state.events.push('exit-start')
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      state.events.push('exit-end')
+    }
+
+    const doTransition = ({ state }: any) => {
+      state.events.push('main')
+    }
+
+    const state = {
+      events: [] as string[],
+    }
+    const actions = {
+      exitAction,
+      doTransition,
+    }
+
+    const config = {
+      state,
+      actions,
+    }
+
+    const chart: Statechart<
+      typeof config,
+      {
+        foo: void
+        bar: void
+      }
+    > = {
+      initial: 'foo',
+      states: {
+        foo: {
+          exit: 'exitAction',
+          on: {
+            doTransition: 'bar',
+          },
+        },
+        bar: {},
+      },
+    }
+
+    const instance = createOvermind(
+      statechart(config, {
+        id1: chart,
+      })
+    )
+
+    await instance.actions.doTransition()
+
+    expect(instance.state.states).toEqual([['id1', 'bar']])
+    // Exit must fully complete (both start and end) before main action
+    expect(instance.state.events).toEqual(['exit-start', 'exit-end', 'main'])
   })
 })

--- a/packages/overmind-statechart/src/index.ts
+++ b/packages/overmind-statechart/src/index.ts
@@ -1,4 +1,11 @@
-import { ENVIRONMENT, IConfiguration, derived, filter, pipe } from 'overmind'
+import {
+  ENVIRONMENT,
+  IConfiguration,
+  derived,
+  filter,
+  isPromise,
+  pipe,
+} from 'overmind'
 
 const ACTIONS = 'ACTIONS'
 const CHART = 'CHART'
@@ -509,52 +516,73 @@ export function statechart<
               }
             })
 
-            // Run exits
-            exitActions.forEach((exitAction) => {
+            function executeTransition() {
+              currentTransitionAction = key
+              let actionResult
               if (config.actions) {
-                actionsTarget[ACTIONS][exitAction](payload)
+                actionResult = actionsTarget[ACTIONS][key](payload)
               }
-            })
 
-            currentTransitionAction = key
-            let actionResult
-            if (config.actions) {
-              actionResult = actionsTarget[ACTIONS][key](payload)
+              currentTransitionAction = null
+
+              // Transition to new state
+              stateTarget.states = newStates
+
+              // Run entry actions
+              entryActions.forEach((entryAction) => {
+                if (config.actions) {
+                  actionsTarget[ACTIONS][entryAction](payload)
+                }
+              })
+
+              if (
+                ENVIRONMENT === 'development' &&
+                currentInstance &&
+                currentInstance.devtools
+              ) {
+                currentInstance.devtools.send({
+                  type: 'chart',
+                  data: {
+                    path: context.execution.namespacePath,
+                    states: stateTarget.states,
+                    charts,
+                    actions: getCanTransitionActions(
+                      copiedActions,
+                      charts,
+                      stateTarget
+                    ),
+                  },
+                })
+              }
+
+              return actionResult
             }
 
-            currentTransitionAction = null
-
-            // Transition to new state
-            stateTarget.states = newStates
-
-            // Run entry actions
-            entryActions.forEach((entryAction) => {
+            // Run exits, awaiting any that return promises
+            const exitResults: any[] = []
+            exitActions.forEach((exitAction) => {
               if (config.actions) {
-                actionsTarget[ACTIONS][entryAction](payload)
+                exitResults.push(actionsTarget[ACTIONS][exitAction](payload))
               }
             })
 
-            if (
-              ENVIRONMENT === 'development' &&
-              currentInstance &&
-              currentInstance.devtools
-            ) {
-              currentInstance.devtools.send({
-                type: 'chart',
-                data: {
-                  path: context.execution.namespacePath,
-                  states: stateTarget.states,
-                  charts,
-                  actions: getCanTransitionActions(
-                    config.actions,
-                    charts,
-                    stateTarget
-                  ),
-                },
+            const pendingExits = exitResults.filter(isPromise)
+
+            if (pendingExits.length) {
+              return Promise.all(pendingExits).then(() => {
+                // Re-validate that the transition is still valid after
+                // async exit actions complete, since state may have
+                // changed during the async gap
+                const canStillTransition = stateTarget.actions[key]
+                if (!canStillTransition) {
+                  return
+                }
+
+                return executeTransition()
               })
             }
 
-            return actionResult
+            return executeTransition()
           }
         )
 

--- a/packages/overmind/src/index.ts
+++ b/packages/overmind/src/index.ts
@@ -13,7 +13,14 @@ export type {
   ContextFunction,
 } from './internalTypes'
 export { createOperator, createMutationOperator } from './operator'
-export { MODE_DEFAULT, MODE_TEST, MODE_SSR, ENVIRONMENT, json } from './utils'
+export {
+  MODE_DEFAULT,
+  MODE_TEST,
+  MODE_SSR,
+  ENVIRONMENT,
+  json,
+  isPromise,
+} from './utils'
 export { SERIALIZE, rehydrate } from './rehydrate'
 export {
   type MachineMethods,

--- a/packages/overmind/src/operators.test.ts
+++ b/packages/overmind/src/operators.test.ts
@@ -363,6 +363,42 @@ describe('OPERATORS', () => {
     )
   })
 
+  test('throttle passes most recent value', () => {
+    expect.assertions(2)
+    const test = pipe(throttle(0), ({ state }: Context, value: number) => {
+      state.lastValue = value
+      state.runCount++
+    })
+    const state = {
+      lastValue: -1,
+      runCount: 0,
+    }
+    const actions = {
+      test,
+    }
+    const config = {
+      state,
+      actions,
+    }
+    const overmind = new Overmind(config)
+
+    type Context = IContext<{
+      state: typeof state
+      actions: {
+        test: typeof actions.test
+      }
+    }>
+
+    return Promise.all([
+      overmind.actions.test(1),
+      overmind.actions.test(2),
+      overmind.actions.test(3),
+    ]).then(() => {
+      expect(overmind.state.runCount).toBe(1)
+      expect(overmind.state.lastValue).toBe(3)
+    })
+  })
+
   test('catchError', () => {
     expect.assertions(3)
     const test = pipe(

--- a/packages/overmind/src/operators.ts
+++ b/packages/overmind/src/operators.ts
@@ -535,6 +535,7 @@ export function throttle<T>(ms: number): IOperator<T, T> {
   let timeout: any
   let previousFinal: any
   let currentNext: any
+  let currentValue: any
 
   return createOperator(
     'throttle',
@@ -548,11 +549,12 @@ export function throttle<T>(ms: number): IOperator<T, T> {
         } else {
           timeout = setTimeout(() => {
             timeout = null
-            currentNext(null, value)
+            currentNext(null, currentValue)
           }, ms)
         }
         previousFinal = final
         currentNext = next
+        currentValue = value
       }
     }
   )


### PR DESCRIPTION
## Summary

- Fix statechart exit actions not being awaited when async, breaking exit → action → transition → entry ordering
- Fix devtools incorrectly showing `onInitializeOvermind` as a transition action after state changes
- Fix throttle operator passing the first invocation's value instead of the most recent one

## Bug Fixes

### 1. Statechart: async exit actions not awaited before transitions

When a statechart exit action was async (plain `async function` or operator-based via `pipe`), the returned
Promise was discarded. The main action, state transition, and entry actions executed immediately without
waiting for exit to complete.

The `runAction` wrapper now collects exit action return values, detects Promises via `isPromise`, and
`Promise.all()`s them before proceeding. After async exits complete, it re-validates the transition is
still valid since another action may have changed state during the async gap. The synchronous code path
is unchanged.

### 2. Statechart: wrong actions object passed to devtools

After a state transition, the devtools update used `config.actions` (which includes `onInitializeOvermind`)
instead of `copiedActions` (which has it removed). The other two call sites already used `copiedActions`
correctly.

### 3. Throttle operator passes stale value

The throttle operator's `setTimeout` closure captured `value` from the first invocation. Subsequent calls
updated `currentNext` but not the value inside the already-scheduled timeout. Added a `currentValue`
variable updated on every invocation so the timeout fires with the most recent value.

## Other Changes

- Exported `isPromise` from overmind's public API so `overmind-statechart` can import it instead of
  duplicating the implementation
- Added 6 new statechart tests covering operator-based actions and async exit ordering
- Added 1 new throttle test verifying the most recent value is passed downstream